### PR TITLE
Update for vscode-maniascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Change Log
 Latest information regarding vscode-maniascript
 
+## 1.2.1
+
+Add support for snippets  
+Modules bug fix
+
 ## 1.2.0
-Add types completion and function overloading
+
+Add types completion and function overloading  
 Update the completion.json file to lastest version of maniascript (website used : https://www.uaseco.org/maniascript/2018-03-29/annotated.html)
+Use of https://github.com/Noomaok/maniascript-completion-updater to generate the completions.json file
 
 ## 1.1.3
+
 Add missing repository field to package.json
 
 ## 1.1.2
@@ -33,6 +41,7 @@ Official release
 Documentation fixes : Fixed an issue where broken links occurred with png file links
 
 ## 0.3.0
+
 Implemented support for labels
   - Expand / collapse code blocks when indented
 
@@ -47,9 +56,10 @@ Implemented support for template strings with embedded scripts
 <img src="https://github.com/MattMcFarland/vscode-maniascript/raw/master/images/template-string.png"/>
 
 ## 0.2.0
-Add icon for marketplace in vs code
-Change name from "maniascript grammar" to "mania script"
-Implement YAML and build src to tmLanguage file
+
+Add icon for marketplace in vs code  
+Change name from "maniascript grammar" to "mania script"  
+Implement YAML and build src to tmLanguage file  
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 Latest information regarding vscode-maniascript
 
+## 1.2.0
+Add types completion and function overloading
+Update the completion.json file to lastest version of maniascript (website used : https://www.uaseco.org/maniascript/2018-03-29/annotated.html)
+
 ## 1.1.3
 Add missing repository field to package.json
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For more information about ManiaScript, see https://doc.maniaplanet.com/maniascr
 
 - Snippets have not been implemented yet.
 - Linting has not been implemented yet.
+- When starting by the character '#' the completion add an extra '#' when selecting a term.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # vscode-maniascript README
 
-VSCode Grammar / Autocompletion support for ManiaScript; `".Script.txt"` files.
-For more information about ManiaScript, see https://doc.maniaplanet.com/maniascript
+VSCode Grammar / Autocompletion support for ManiaScript; `".Script.txt"` files.  
+For more information about ManiaScript, see https://doc.maniaplanet.com/maniascript  
+A full documentation can be found here : https://www.uaseco.org/maniascript/2018-03-29/annotated.html
 
 ![Demo](https://github.com/MattMcFarland/vscode-maniascript/raw/master/images/intellisense.gif)
 
 ## Known Issues
 
-- Snippets have not been implemented yet.
 - Linting has not been implemented yet.
-- When starting by the character '#' the completion add an extra '#' when selecting a term.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # vscode-maniascript README
 
 VSCode Grammar / Autocompletion support for ManiaScript; `".Script.txt"` files.
-For more information about ManiaScript, see http://doc.maniaplanet.com/creation/maniascript/index.html
+For more information about ManiaScript, see https://doc.maniaplanet.com/maniascript
 
 ![Demo](https://github.com/MattMcFarland/vscode-maniascript/raw/master/images/intellisense.gif)
 
 ## Known Issues
 
-- Intellisense can suggest all known types from the manaiscript documentation, but it cannot infer types just yet.
 - Snippets have not been implemented yet.
 - Linting has not been implemented yet.
 

--- a/lib/completions/classes.js
+++ b/lib/completions/classes.js
@@ -33,9 +33,14 @@ module.exports = {
     const allProps = []
     const groupNames = Object.keys(props)
     groupNames.forEach(groupName => {
-      allProps.push(...props[groupName])
+      //allProps.push(...props[groupName])
+      props[groupName].forEach(prop => {
+        var itemProp = new Item(prop + " : " + groupName , Kind.Field)
+        itemProp.insertText = prop
+        allProps.push(itemProp)
+      })
     })
-    return allProps.map(label => new Item(label, Kind.Field))
+    return allProps
   }
 }
 

--- a/lib/completions/classes.js
+++ b/lib/completions/classes.js
@@ -4,8 +4,29 @@ const { CompletionItem: Item, CompletionItemKind: Kind } = require('vscode')
 module.exports = {
   classes: Object.keys(classes).map(label => new Item(label, Kind.Class)),
   classMethods: (className) => {
-    const methods = classes[className].methods || {}
-    return Object.keys(methods).map(label => new Item(label, Kind.Method))
+    const groupMethods = classes[className].methods || {}
+    var textCompletions = []
+    var objs = Object.keys(groupMethods).map(label => {
+      var textDisplay = groupMethods[label].name+"("
+      var textCompletion = groupMethods[label].name+"("
+      const params = groupMethods[label].params
+      if (params.length > 0) {
+        params.forEach(param => {
+          textDisplay += param.identifier + " " + param.argument + ", "
+          textCompletion += param.argument + ", "
+        })
+        textDisplay = textDisplay.substring(0, textDisplay.length-2);
+        textCompletion = textCompletion.substring(0, textCompletion.length-2);
+      }
+      textDisplay += ") : "+groupMethods[label].returns
+      textCompletion += ")"
+      textCompletions.push(textCompletion)
+      return new Item(textDisplay, Kind.Method)
+    })
+    for(var i = 0; i < textCompletions.length; i++){
+      objs[i].insertText = textCompletions[i]
+    }
+    return objs
   },
   classProps: (className) => {    
     const props = classes[className].props || {}

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -294,6 +294,244 @@
         }
       }
     },
+    "CAudioSourceMusic": {
+      "props": {
+        "Real[]": [
+          "Tracks_Volume",
+          "Tracks_VolumedB",
+          "Tracks_Length"
+        ],
+        "Text[]": [
+          "Tracks_Name"
+        ],
+        "Integer": [
+          "Tracks_Count",
+          "BeatsPerBar"
+        ],
+        "Real": [
+          "BeatsPerMinute",
+          "BeatDuration",
+          "LPF_CutoffRatio",
+          "LPF_Q",
+          "HPF_CutoffRatio",
+          "HPF_Q",
+          "FadeTracksDuration",
+          "FadeFiltersDuration"
+        ],
+        "EUpdateMode": [
+          "UpdateMode"
+        ],
+        "Boolean": [
+          "Dbg_ForceIntensity",
+          "Dbg_ForceSequential",
+          "Dbg_ForceRandom",
+          "UseNewImplem"
+        ]
+      }
+    },
+    "CBadge": {
+      "props": {
+        "Vec3": [
+          "PrimaryColor"
+        ],
+        "Text": [
+          "SkinName"
+        ],
+        "Text[]": [
+          "Layers"
+        ]
+      },
+      "methods": {
+        "StickerSlot_Get": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Slot"
+            }
+          ],
+          "return": "Text"
+        },
+        "StickerSlot_Set": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Slot"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Sticker"
+            }
+          ],
+          "return": "Void"
+        },
+        "StickerSlot_Clear": {
+          "params": [],
+          "return": "Void"
+        }
+      }
+    },
+    "CBadgeEditor": {
+      "props": {
+        "CBadge": [
+          "DisplayCurrentBadge"
+        ],
+        "Vec2": [
+          "DisplayPosN",
+          "DisplaySize"
+        ],
+        "Real": [
+          "DisplayFoV",
+          "CameraTransitionDuration",
+          "MeshRotation_MaxSpeed",
+          "MeshRotation_Acceleration"
+        ],
+        "Ident": [
+          "DisplayCurrentMeshId"
+        ],
+        "Ident[]": [
+          "MeshIds"
+        ],
+        "CBadge[]": [
+          "Badges"
+        ]
+      },
+      "methods": {
+        "Leave": {
+          "params": [],
+          "return": "Void"
+        },
+        "MeshId_Next": {
+          "params": [],
+          "return": "Void"
+        },
+        "MeshId_Previous": {
+          "params": [],
+          "return": "Void"
+        },
+        "BadgeCreate": {
+          "params": [],
+          "return": "CBadge"
+        },
+        "BadgeDestroy": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeCopy": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Source"
+            },
+            {
+              "identifier": "CBadge",
+              "argument": "Destination"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeReadFromProfile": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeWriteToProfile": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "return": "Void"
+        }
+      }
+    },
+    "CBadgeManager": {
+      "props": {
+        "CBadge[]": [
+          "Badges"
+        ]
+      },
+      "methods": {
+        "BadgeCreate": {
+          "params": [],
+          "return": "CBadge"
+        },
+        "BadgeDestroy": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeCopy": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Source"
+            },
+            {
+              "identifier": "CBadge",
+              "argument": "Destination"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeReadFromProfile": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "return": "Void"
+        },
+        "BadgeWriteToProfile": {
+          "params": [
+            {
+              "identifier": "CBadge",
+              "argument": "Badge"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "return": "Void"
+        },
+        "ProfileIsReady": {
+          "param": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "return": "Boolean"
+        }
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -11,6 +11,289 @@
     "Ident"
   ],
   "classes": {
+    "CAchievementsAchievement": {
+      "props": {
+        "Ident": [
+          "UserId"
+        ],
+        "CAchievementsAchievementDesc": [
+          "AchievementDesc"
+        ]
+      }
+    },
+    "CAchievementsAchievementDesc": {
+      "props": {
+        "Text": [
+          "TitleId",
+          "DisplayName",
+          "Description",
+          "IconUrl"
+        ]
+      }
+    },
+    "CAchievementsEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CAchievementsAchievement": [
+          "Achievement"
+        ]
+      }
+    },
+    "CAchievementsManager": {
+      "props": {
+        "CAchievementsEvent[]": [
+          "PendingEvents"
+        ],
+        "CAchievementsAchievement[]": [
+          "Achievements"
+        ],
+        "CAchievementsStat[]": [
+          "Stats"
+        ],
+        "CAchievementsAchievementDesc[]": [
+          "AchivementsDescriptions"
+        ],
+        "CAchievementsStatDesc[]": [
+          "StatDescriptions"
+        ]
+      },
+      "methods":{
+        "SendEvent":{
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument" : "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Mnemo"
+            },
+            {
+              "identifier": "Integer[]",
+              "argument": "Params"
+            }
+          ],
+          "return" : "Void"
+        }
+      }
+    },
+    "CAchievementsStat":{
+      "props": {
+        "Ident":[
+          "UserId"
+        ],
+        "CAchievementsStatDesc":[
+          "StatDesc"
+        ],
+        "Integer":[
+          "Value"
+        ]
+      }
+    },
+    "CAchievementsStatDesc": {
+      "props": {
+        "Text":[
+          "TitleId",
+          "DisplayName",
+          "Description"
+        ]
+      }
+    },
+    "CAnchorData": {
+      "props": {
+        "Text": [
+          "DefaultTag",
+          "Tag"
+        ],
+        "Integer": [
+          "DefaultOrder",
+          "Order"
+        ],
+        "CBlock": [
+          "Block"
+        ],
+        "CItemAnchor": [
+          "Item"
+        ]
+      }
+    },
+    "CAnimManager": {
+      "methods": {
+        "Add": {
+          "params": [
+            {
+              "identifier": "CMlControl",
+              "argument": "Control"
+            },
+            {
+              "identifier": "Text",
+              "argument": "XmlTarget"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "StartTime"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Duration"
+            },
+            {
+              "identifier": "EAnimManagerEasing",
+              "argument": "EasingFunc"
+            }
+          ],
+          "return": "Void"
+        },
+        "AddChain": {
+          "params": [
+            {
+              "identifier": "CMlControl",
+              "argument": "Control"
+            },
+            {
+              "identifier": "Text",
+              "argument": "XmlTarget"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Duration"
+            },
+            {
+              "identifier": "EAnimManagerEasing",
+              "argument": "EasingFunc"
+            }
+          ],
+          "return": "Void"
+        }
+      }
+    },
+    "CAnyEditorPlugin": {
+      "props": {
+        "CManiaAppEvent[]": [
+          "PendingEvents"
+        ],
+        "CEditorModule": [
+          "ModuleEditor"
+        ],
+        "CEditorMesh": [
+          "MeshEditor"
+        ],
+        "CEditorEditor": [
+          "EditorEditor"
+        ],
+        "EInteractionStatus": [
+          "InteractionStatus"
+        ]
+      }
+    },
+    "CAudioManager": {
+      "props": {
+        "CAudioSource[]": [
+          "Sounds"
+        ],
+        "Boolean": [
+          "ForceEnableMusic"
+        ],
+        "Real": [
+          "LimitMusicVolumedB",
+          "LimitSceneSoundVolumedB",
+          "LimitUiSoundVolumedB"
+        ]
+      },
+      "methods": {
+        "CreateSound": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "Real",
+              "argument": "VolumedB"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "IsMusic"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "IsLooping"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "IsSpatialized"
+            }
+          ],
+          "returns": "CAudioSource"
+        },
+        "DestroySound": {
+          "params": [
+            {
+              "identifier": "CAudioSource",
+              "argument": "Sound"
+            }
+          ],
+          "returns": "Void"
+        },
+        "PlaySoundEvent": {
+          "params": [
+            {
+              "identifier": "ELibSound",
+              "argument": "Sound"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "SoundVariant"
+            },
+            {
+              "identifier": "Real",
+              "argument": "VolumedB"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Delay"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ClearAllDelayedSoundsEvents": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CAudioSource": {
+      "props": {
+        "Boolean": [
+          "IsPlaying",
+          "DownloadInProgress"
+        ],
+        "Real": [
+          "Volume",
+          "FadeDuration",
+          "VolumedB",
+          "Pitch",
+          "PlayCursor",
+          "PlayLength"
+        ],
+        "Vec3": [
+          "RelativePosition",
+          "PanRadiusLfe"
+        ]
+      },
+      "methods": {
+        "Play": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Stop": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [
@@ -2386,80 +2669,6 @@
         }
       }
     },
-    "CAudioManager": {
-      "props": {
-        "CAudioSound[]": [
-          "Sounds"
-        ],
-        "Boolean": [
-          "ForceEnableMusic"
-        ],
-        "Real": [
-          "LimitMusicVolumedB"
-        ]
-      },
-      "methods": {
-        "CreateSound": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Real",
-              "argument": "VolumedB"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsMusic"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsLooping"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsSpatialized"
-            }
-          ],
-          "returns": "CAudioSound"
-        },
-        "DestroySound": {
-          "params": [
-            {
-              "identifier": "CAudioSound",
-              "argument": "Sound"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PlaySoundEvent": {
-          "params": [
-            {
-              "identifier": "ELibSound",
-              "argument": "Sound"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SoundVariant"
-            },
-            {
-              "identifier": "Real",
-              "argument": "VolumedB"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Delay"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ClearAllDelayedSoundsEvents": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
     "CMlControl": {
       "props": {
         "Text": [
@@ -2713,18 +2922,6 @@
           "params": [],
           "returns": "Void"
         }
-      }
-    },
-    "CAnchorData": {
-      "props": {
-        "Text": [
-          "DefaultTag",
-          "Tag"
-        ],
-        "Integer": [
-          "DefaultOrder",
-          "Order"
-        ]
       }
     },
     "CMode": {
@@ -3719,34 +3916,6 @@
         "Boolean": [
           "IsCompleted"
         ]
-      }
-    },
-    "CAudioSound": {
-      "props": {
-        "Boolean": [
-          "IsPlaying",
-          "DownloadInProgress"
-        ],
-        "Real": [
-          "Volume",
-          "VolumedB",
-          "Pitch",
-          "PlayCursor",
-          "PlayLength"
-        ],
-        "Vec3": [
-          "RelativePosition"
-        ]
-      },
-      "methods": {
-        "Play": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Stop": {
-          "params": [],
-          "returns": "Void"
-        }
       }
     },
     "CMapInfo": {

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -928,6 +928,1850 @@
         }
       }
     },
+    "CEditorEditor":{
+      "props": {
+        "Boolean": [
+          "Bindings_RequestInput_Done"
+        ],
+        "Text[]": [
+          "BindingContexts",
+          "RequestedContextBindings"
+        ],
+        "CEditorEvent[]": [
+          "PendingEvents"
+        ]
+      },
+      "methods": {
+        "Bindings_AddContext": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_AddBinding": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "BindingScriptId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "BindingDisplayName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_RemoveContext": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_RemoveBinding": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_RequestInput": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_SetBindingScriptId": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingScriptId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "NewBindingScriptId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_SetBindingDisplayName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingScriptId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "BindingDisplayName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_SetContextName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "NewContextName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_GetContextBindings": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Bindings_GetBindingsActionName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingName"
+            }
+          ],
+          "returns": "Text"
+        },
+        "Bindings_GetBindingsDisplayName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingName"
+            }
+          ],
+          "returns": "Text"
+        }
+      }
+    },
+    "CEditorEvent": {
+      "props": {
+        "Type": [
+          "Type"
+        ]
+      }
+    },
+    "CEditorMainPlugin": {
+      "props": {
+        "CEditorPluginHandle[]": [
+          "Plugins"
+        ]
+      },
+      "methods": {
+        "Help_Open": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Help_Close": {
+          "params": [],
+          "returns": "Void"
+        },
+        "GetPluginHandle": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Name"
+            }
+          ],
+          "returns": "CEditorPluginHandle"
+        },
+        "SendPluginEvent": {
+          "params": [
+            {
+              "identifier": "CEditorPluginHandle",
+              "argument": "Handle"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Data"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Context_SetActive": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "IsActive"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Context_IsActive": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ContextName"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Binding_IsActive": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BindingName"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Plugin_SetClearance": {
+          "params": [
+            {
+              "identifier": "CEditorPluginHandle",
+              "argument": "Handle"
+            },
+            {
+              "identifier": "EMeshEditorAPI",
+              "argument": "API"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "IsAllowed"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CEditorMesh": {
+      "props": {
+        "Boolean": [
+          "GoToMaterialEditor",
+          "IsCreateMaterial",
+          "Tmp_UseParts",
+          "EditionBox_IsPlaneOriented",
+          "DisplayVertices",
+          "DisplayFaces",
+          "DisplayJoints",
+          "GripSnap_IsActive",
+          "Display_HideElemsByDistance_IsActive",
+          "IsExperimental"
+        ],
+        "Integer": [
+          "VertexCount",
+          "EdgeCount",
+          "FaceCount",
+          "RotationStep",
+          "MaterialsUpdateId",
+          "Material_Atlas_SelectedSubTexIndex",
+          "CreationElemsCount",
+          "Display_HideElemsByDistance_Distance",
+          "PrefabNamesUpdateId"
+        ],
+        "Real": [
+          "Scale",
+          "Step",
+          "Size",
+          "RotationValue",
+          "ScalingStep",
+          "ScalingRatio",
+          "Display_HideElemsByDistance_Opacity"
+        ],
+        "EEdgesDisplay": [
+          "DisplayEdges"
+        ],
+        "Ident[]": [
+          "MaterialIds"
+        ],
+        "Text[]": [
+          "MaterialNames",
+          "PrefabNames"
+        ],
+        "EInteraction": [
+          "CurrentInteraction"
+        ],
+        "Ident": [
+          "SelectionSet"
+        ],
+        "CEditorEvent[]": [
+          "PendingEvents"
+        ]
+      },
+      "methods": {
+        "EditionBox_SetScale": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "Scale"
+            }
+          ],
+          "returns": "Void"
+        },
+        "EditionBox_OrientPlane": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "EditedMesh_Clear": {
+          "params": [],
+          "returns": "Void"
+        },
+        "EditedMesh_Simplify": {
+          "params": [],
+          "returns": "Void"
+        },
+        "EditedMesh_Lod": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "FacesRatio"
+            }
+          ],
+          "returns": "Void"
+        },
+        "UVUnwrap": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "ETexCoordLayer",
+              "argument": "ETexCoordLayer"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Undo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Redo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SwitchPlane": {
+          "params": [],
+          "returns": "Void"
+        },
+        "GridSnap_SetActive": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsActive"
+            }
+          ],
+          "returns": "Void"
+        },
+        "PickInfo_GetNormal": {
+          "params": [],
+          "returns": "Vec3"
+        },
+        "PickInfo_GetPosition": {
+          "params": [],
+          "returns": "Vec3"
+        },
+        "PickInfo_GetEdgeLength": {
+          "params": [],
+          "returns": "Real"
+        },
+        "PickInfo_GetNextVertexPosition": {
+          "params": [],
+          "returns": "Vec3"
+        },
+        "PickInfo_GetMaterial": {
+          "params": [],
+          "returns": "Ident"
+        },
+        "PickInfo_GetError": {
+          "params": [],
+          "returns": "Text"
+        },
+        "Part_SetAnchorPos": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Part_SetIsJoint": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsJoint"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Part_ClearAnchor": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Material_GetMaterialIdSelected": {
+          "params": [],
+          "returns": "Ident"
+        },
+        "Material_SetMaterailIdSelected": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialEditorId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Materail_GetSubTexIndexSelected": {
+          "params": [],
+          "returns": "Integer"
+        },
+        "Material_MaterialLibGetCount": {
+          "params": [],
+          "returns": "Integer"
+        },
+        "Material_SetDefault": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_GetDefault": {
+          "params": [],
+          "returns": "Ident"
+        },
+        "Material_GetBitmapBase": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            }
+          ],
+          "returns": "CImage"
+        },
+        "Material": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            }
+          ],
+          "returns": "CImage"
+        },
+        "Material_MatchesCriterion": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            },
+            {
+              "identifier": "EMaterialFilterCriterion",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Material_SetFilter": {
+          "params": [
+            {
+              "identifier": "EMaterialFilterCriterion",
+              "argument": "Criterion"
+            },
+            {
+              "identifier": "EFilterKind",
+              "argument": "FilterKind"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_GetFilter": {
+          "params": [
+            {
+              "identifier": "EMaterialFilterCriterion",
+              "argument": "Criterion"
+            }
+          ],
+          "returns": "EFilterKind"
+        },
+        "Material_ClearFilters": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Material_UVEditor_SetIsRotation": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsRotation"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_UVEditor_SetIsScale": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsScale"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_UVEditor_SetIsScale1D": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsScale"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_UVEditor_Open": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            },
+            {
+              "identifier": "CMlQuad",
+              "argument": "LocationQuad"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_UVEditor_Close": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Material_UVEditor_SetMode": {
+          "params": [
+            {
+              "identifier": "EUVEditorMode",
+              "argument": "Mode"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_UVEditor_GetMode": {
+          "params": [],
+          "returns": "EUVEditorMode"
+        },
+        "Material_UVEditor_SetProjectionType": {
+          "params": [
+            {
+              "identifier": "EUVEditorProjectionType",
+              "argument": "ProjectionType"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Material_IsGameMaterial": {
+          "params": [],
+          "returns": "Boolean"
+        },
+        "Material_UVEditor_Apply": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Material_PasteMaterial": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Abort": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_SetPreview": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetToPreview"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartCreation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "CreationSetHandle"
+            },
+            {
+              "identifier": "EElemType",
+              "argument": "ElemType"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SetToPickFromHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Creation_GetElems": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_CloseCreation": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_Creation_ClearParams": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_Creation_SetEdgesConstraint": {
+          "params": [
+            {
+              "identifier": "EEdgesConstraint",
+              "argument": "EdgesConstraint"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Creation_SetAutoMerge": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "AutoMerge"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPaste": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_StartBlocTransformation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TransformationSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartCurve2D": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BordersSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_CloseCurve2D": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "CanDoCurve2D"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPick": {
+          "params": [
+            {
+              "identifier": "EElemType",
+              "argument": "ElemType"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SetToPickFrom"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPickJoint": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_StartMerge": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "MergeSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartMirror": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Selection_ClearParams": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_Selection_SetUseParts": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "UseParts"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Selection_SetCanEnterLeaf": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "CanEnterLeaf"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartSelection": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SelectionSetHandle"
+            },
+            {
+              "identifier": "EElemType",
+              "argument": "ElemType"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SelectionSetToPickFrom"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_CloseSelection": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Interaction_StartTranslation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TranslationSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPickTranslation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TranslationSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartRotation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "RotationSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPickRotation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "RotationSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Rotation_SetStep": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "RotationStep"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartPickScale": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ScalingSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_Scale_SetStep": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "ScalingStep"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Interaction_StartSplit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Display_HighlightSet": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Display_ClearHighlighting": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Display_AtlasSelectionsSet": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "DisplayAtlasSelection"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Display_AtlasSelectionGet": {
+          "params": [],
+          "returns": "Boolean"
+        },
+        "Display_HideElemsByDistance_Start": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Display_HideElemsByDistance_Stop": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Display_HideMap": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Display_ShowMap": {
+          "params": [],
+          "returns": "Void"
+        },
+        "MergeAllSuperposedElements": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Selection_Undo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Selection_Redo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetOfElements_Create": {
+          "params": [],
+          "returns": "Ident"
+        },
+        "SetOfElements_CopyFrom": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "DestinationSet"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SourceSet"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_Append": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "DestinationSet"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SourceSet"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_Destroy": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_Empty": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_SetAllElements": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_SetAllFaces": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_DeleteElements": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfELements_HasHorizontalFaces": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "SetOfElements_HasVerticalFaces": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "SetOfElements_GetElemsCount": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "SetOfElements_GetVerticesCount": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "SetOfElements_GetEdgesCount": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "SetOfElements_GetFacesCount": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "ExtendSelectedSet": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetBordersSet": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SetBordersHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetBordersVertexs": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SetVertexHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SelectionSet_SelectAll": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Curve2DPolygon": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "FourVertexSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "SubTexIndex"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AtlasSelection_Create": {
+          "params": [],
+          "returns": "Ident"
+        },
+        "AtlasSelection_GetAtlasSelectionHandleFromSet": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AtlasSelection_GAddAtlasSelectionFromSet": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "FourPointsHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AtlasSelection_SubAtlasSelection": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AtlasSelection_TextureAtlasSelection": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "SubTexIndex"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AtlasSelection_GetAtlasSelectionAfterSelection": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Preview_Clear": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BlocTransformation_Start": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "BlocTransformation_Translate": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Translation"
+            }
+          ],
+          "returns": "Void"
+        },
+        "BlocTransformation_Twist": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "Angle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "BlocTransformation_Bend": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Axis"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Radius"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Angle"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Direction"
+            }
+          ],
+          "returns": "Void"
+        },
+        "BlocTransformation_Abort": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BlocTransformation_Close": {
+          "params": [],
+          "returns": "Void"
+        },
+        "VoxelSpace_Init": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Size"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "UseColors"
+            }
+          ],
+          "returns": "Void"
+        },
+        "VoxelSpace_Destroy": {
+          "params": [],
+          "returns": "Void"
+        },
+        "VoxelSpace_Get": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Pos"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "VoxelSpace_Set": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Pos"
+            }
+          ],
+          "returns": "Void"
+        },
+        "VoxelSpace_SetVec3": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Pos"
+            }
+          ],
+          "returns": "Void"
+        },
+        "VoxelSpace_Unset": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Pos"
+            }
+          ],
+          "returns": "Void"
+        },
+        "VoxelSpace_GenerateMesh": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetOfElements_ProjectOnPlane": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_ProjectOnGround": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Height"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_SplitEdgeWithVertex": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_CoolapseEdgeWithVertex": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_Subdivide": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfElements_Subdivide_Interpolation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawCircle": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "InputSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawDisc": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "InputSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawIcosahedron": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "InputSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawIcosahedricSphere": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "InputSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawPoly": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "InputSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "VerticesCount"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawSpline": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ControlSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_Weld": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "VerticesSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfVertices_DrawBox": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ControlSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfEdges_Fill": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfEdges_Flip": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfEdges_BorderExpand": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfOneEdge_FaceLoopExpand": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfOneEdge_EdgeLoopExpand": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfOneFace_CutHole": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "FaceSetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "EdgesSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfFaces_Extrude": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfFaces_QuadsToTriangles": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "ResultSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfFaces_ApplyMaterial": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "SetHandle"
+            },
+            {
+              "identifier": "Ident",
+              "argument": "MaterialId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfFaces_PlanarExpand": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "FacesSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetOfFaces_ChangeOrientation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "FacesSetHandle"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Prefab_Export": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Prefab_Import": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "PrefabIndex"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Parts_MergeSelectedParts": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Parts_Group": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Parts_UngroupSelectedParts": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Cut": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Copy": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetBaseUndoState": {
+          "params": [],
+          "returns": "Void"
+        },
+        "AddUndoState": {
+          "params": [],
+          "returns": "Void"
+        },
+        "AutoSave": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CEditorModule": {
+      "props": {
+        "CModuleMenuModel": [
+          "EditedMenu"
+        ],
+        "CModuleMenuPageModel": [
+          "EditedMenuPage"
+        ],
+        "CeditorPluginModuleEvent[]": [
+          "PendingEvents"
+        ]
+      },
+      "methods": {
+        "NewModule": {
+          "params": [
+            {
+              "identifier": "EModuleType",
+              "argument": "ModuleType"
+            }
+          ],
+          "returns": "Void"
+        },
+        "OpenModule": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Save": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SaveAs": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SaveCopyAs": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ForceExit": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CEditorPluginModuleEvent": {
+      "props": {
+        "Type": [
+          "Type"
+        ]
+      },
+      "methods": {
+        "Eat": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CGameMatchSettingsPlaylistItemScript": {
+      "props": {
+        "Text": [
+          "Name"
+        ],
+        "Boolean": [
+          "FileExists"
+        ]
+      }
+    },
+    "CGameModeInfo": {
+      "props": {
+        "Text": [
+          "Name",
+          "Path",
+          "Description",
+          "Version"
+        ],
+        "Text[]": [
+          "CompatibleMapTypes"
+        ]
+      }
+    },
+    "CGamePlayerMapRecordScript": {
+      "props": {
+        "Text": [
+          "Context",
+          "MapUid",
+          "MapName",
+          "FileName",
+          "ReplayUrl"
+        ],
+        "Integer": [
+          "Score",
+          "Time",
+          "RespawnCount",
+          "Timestamp",
+          "MultiAsyncLevel",
+          "SkillPoints"
+        ]
+      }
+    },
+    "CGhost": {
+      "props": {
+        "Ident": [
+          "Id"
+        ],
+        "CTmResult": [
+          "Result"
+        ],
+        "Text": [
+          "Nickname"
+        ]
+      }
+    },
+    "CHighScoreComparison": {
+      "props": {
+        "CMapInfo": [
+          "MapInfo"
+        ],
+        "Text": [
+          "Login",
+          "RecordDateString",
+          "OpponentLogin",
+          "OpponentDisplayName",
+          "OpponentRecordUrl",
+          "OpponentRecordDateString"
+        ],
+        "Integer": [
+          "RecordScore",
+          "RecordTime",
+          "RecordRespawnCount",
+          "RecordDate",
+          "RecordElapsedTime",
+          "RecordCount",
+          "OpponentRecordScore",
+          "OpponentRecordTime",
+          "OpponentRecordResawnCount",
+          "OpponentRecordDate",
+          "OpponentRecordElapsedTime",
+          "OpponentRecordCount"
+        ]
+      }
+    },
+    "CHighScoreComparisonSummary": {
+      "props": {
+        "Text": [
+          "Login",
+          "BestRecordLastDateString",
+          "OpponentLogin",
+          "OpponentDisplayName",
+          "OppenentBestRecordLasDateString"
+        ],
+        "Integer": [
+          "BestRecordCount",
+          "BestRecordLastDate",
+          "BestRecordElapsedTime",
+          "OpponentBestRecordCount",
+          "OpponentBestRecordLastDate",
+          "OpponentBestRecordElapsedTime"
+        ]
+      }
+    },
+    "CHttpManager": {
+      "props": {
+        "CHttpRequest[]": [
+          "Requests"
+        ],
+        "Integer": [
+          "SlotsAvailable"
+        ],
+        "Boolean": [
+          "AutomaticHeaders_Timezone"
+        ]
+      },
+      "methods": {
+        "CreateGet": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "UseCache"
+            }
+          ],
+          "returns": "CHttpRequest"
+        },
+        "CreatePost": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Resource"
+            }
+          ],
+          "returns": "CHttpRequest"
+        },
+        "Destroy": {
+          "params": [
+            {
+              "identifier": "CHttpRequest",
+              "argument": "Request"
+            }
+          ],
+          "returns": "Void"
+        },
+        "IsValidUrl": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Boolean"
+        }
+      }
+    },
+    "CHttpRequest": {
+      "props": {
+        "Text": [
+          "Url",
+          "Result"
+        ],
+        "Integer": [
+          "StatusCode"
+        ],
+        "Boolean": [
+          "IsCompleted"
+        ]
+      }
+    },
+    "CInputEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CInputPad": [
+          "Pad"
+        ],
+        "EButton": [
+          "Button"
+        ],
+        "Boolean": [
+          "IsAutoRepeat"
+        ],
+        "Integer": [
+          "KeyCode"
+        ],
+        "Text": [
+          "KeyName"
+        ]
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [
@@ -3247,62 +5091,6 @@
         }
       }
     },
-    "CHttpManager": {
-      "props": {
-        "CHttpRequest[]": [
-          "Requests"
-        ],
-        "Integer": [
-          "SlotsAvailable"
-        ]
-      },
-      "methods": {
-        "CreateGet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseCache"
-            }
-          ],
-          "returns": "CHttpRequest"
-        },
-        "CreatePost": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Resource"
-            }
-          ],
-          "returns": "CHttpRequest"
-        },
-        "Destroy": {
-          "params": [
-            {
-              "identifier": "CHttpRequest",
-              "argument": "Request"
-            }
-          ],
-          "returns": "Void"
-        },
-        "IsValidUrl": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
     "CMlControl": {
       "props": {
         "Text": [
@@ -4483,20 +6271,6 @@
           ],
           "returns": "CXmlNode"
         }
-      }
-    },
-    "CHttpRequest": {
-      "props": {
-        "Text": [
-          "Url",
-          "Result"
-        ],
-        "Integer": [
-          "StatusCode"
-        ],
-        "Boolean": [
-          "IsCompleted"
-        ]
       }
     },
     "CMapInfo": {

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -2772,6 +2772,446 @@
         ]
       }
     },
+    "CInputManager": {
+      "props": {
+        "CInputEvent[]": [
+          "PendingEvents"
+        ],
+        "Integer": [
+          "Now",
+          "Period",
+          "Dbg_AutoRepeat_I,itialDelay",
+          "Dbg_AutoRepea_Period"
+        ],
+        "CInputPad[]": [
+          "Pads"
+        ],
+        "Vec2": [
+          "MousePos"
+        ],
+        "Boolean": [
+          "MouseLeftButton",
+          "MouseRightButton",
+          "MouseMiddleButton",
+          "ExclusiveMode"
+        ]
+      },
+      "methods": {
+        "GetPadButtonPlaygroundBinding": {
+          "params": [
+            {
+              "identifier": "CInputPad",
+              "argument": "Pad"
+            },
+            {
+              "identifier": "EButton",
+              "argument": "Button"
+            }
+          ],
+          "returns": "Text"
+        },
+        "GetPadButtonCurrentBinding": {
+          "params": [
+            {
+              "identifier": "CInputPad",
+              "argument": "Pad"
+            },
+            {
+              "identifier": "EButton",
+              "argument": "Button"
+            }
+          ],
+          "returns": "Text"
+        },
+        "GetPadButtonBinding": {
+          "params": [
+            {
+              "identifier": "CInputPad",
+              "argument": "Pad"
+            },
+            {
+              "identifier": "EButton",
+              "argument": "Button"
+            }
+          ],
+          "returns": "Text"
+        },
+        "IsKeyPressed": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "KeyCode"
+            }
+          ],
+          "returns": "Boolean"
+        }
+      }
+    },
+    "CInputPad": {
+      "props": {
+        "Integer": [
+          "ControllerId",
+          "IdleDuration",
+          "Left",
+          "Right",
+          "Up",
+          "Down",
+          "A",
+          "B",
+          "X",
+          "Y",
+          "L1",
+          "R1",
+          "LeftStickBut",
+          "RightStickBut",
+          "Menu",
+          "View"
+        ],
+        "Ident": [
+          "UserId"
+        ],
+        "EPadType": [
+          "Type"
+        ],
+        "Text": [
+          "ModelName"
+        ],
+        "Real": [
+          "LeftStickX",
+          "LeftStickY",
+          "RightStickX",
+          "RightStickY",
+          "L2",
+          "R2"
+        ],
+        "EButton[]": [
+          "ButtonEvents"
+        ]
+      },
+      "methods": {
+        "ClearRumble": {
+          "params": [],
+          "returns": "Void"
+        },
+        "AddRumble": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Duration"
+            },
+            {
+              "identifier": "Real",
+              "argument": "LargeMotor"
+            },
+            {
+              "identifier": "Real",
+              "argument": "SmallMotor"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetColor": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Color"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CItemAnchor": {
+      "props": {
+        "Vec3": [
+          "Position"
+        ]
+      }
+    },
+    "CMacroblockModel": {
+      "props": {
+        "Boolean": [
+          "IsGround",
+          "HasStart",
+          "HasFinish",
+          "HasCheckpoint"
+        ],
+        "CBlockModel": [
+          "GeneratedBlockModel"
+        ],
+        "Text": [
+          "Name"
+        ]
+      }
+    },
+    "CManiaApp": {
+      "props": {
+        "Text": [
+          "ManiaAppUrl",
+          "ManiaAppBaseUrl",
+          "CurrentLocalDateText",
+          "CurrentTimezone"
+        ],
+        "Integer": [
+          "Now",
+          "CurrentDate",
+          "LayersDefaultManialinkVersion"
+        ],
+        "Boolean": [
+          "IsVisible",
+          "EnableMenuNavigationInputs"
+        ],
+        "CUser": [
+          "LocalUser"
+        ],
+        "CTitle": [
+          "LoadedTitle"
+        ],
+        "ESystemPlatform": [
+          "SystemPlatform"
+        ],
+        "ESystemSkuIdentifier": [
+          "SystemSkuIdentifier"
+        ],
+        "CUILayer[]": [
+          "UILayers"
+        ],
+        "CXmlManager": [
+          "Xml"
+        ],
+        "CHttpManager": [
+          "Http"
+        ],
+        "CVideoManager": [
+          "Video"
+        ],
+        "CAudioManager": [
+          "Audio"
+        ],
+        "CInputManager": [
+          "Input"
+        ],
+        "CDataFileMgr": [
+          "DataFileMgr"
+        ],
+        "CScoreMgr": [
+          "ScoreMgr"
+        ],
+        "CPrivilegeMgr": [
+          "PrivilegeMgr"
+        ],
+        "CPresenceMgr": [
+          "PresenceMgr"
+        ],
+        "CUserV2Manager": [
+          "UserMgr"
+        ]
+      },
+      "methods": {
+        "UILayerCreate": {
+          "params": [],
+          "returns": "CUILayer"
+        },
+        "UILayerDestroy": {
+          "params": [
+            {
+              "identifier": "CUILayer",
+              "argument": "Layer"
+            }
+          ],
+          "returns": "Void"
+        },
+        "UILayerDestroyAll": {
+          "params": [],
+          "returns": "Void"
+        },
+        "LayerCustomEvent": {
+          "params": [
+            {
+              "identifier": "CUILayer",
+              "argument": "Layer"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Data"
+            }
+          ],
+          "returns": "Void"
+        },
+        "OpenLink": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "ELinkType",
+              "argument": "LinkType"
+            }
+          ],
+          "returns": "Void"
+        },
+        "OpenFileExplorer": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Dialog_Message": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Message"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Dbg_DumpDeclareForVariables": {
+          "params": [
+            {
+              "identifier": "CNod",
+              "argument": "Nod"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "StatsOnly"
+            }
+          ],
+          "returns": "Text"
+        }
+      }
+    },
+    "CManiaAppBase": {
+      "props": {
+        "CManiaAppEvent[]": [
+          "PendingEvents"
+        ]
+      }
+    },
+    "CManiaAppBrowser": {
+      "props": {
+        "CManiaAppEvent[]": [
+          "PendingEvents"
+        ],
+        "Text": [
+          "BrowserFocusedFrameId"
+        ]
+      },
+      "methods": {
+        "BrowserBack": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserQuit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserHome": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserReload": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CManiaAppEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CUILayer": [
+          "CustomEventLayer"
+        ],
+        "Text": [
+          "CustomEventType",
+          "ExternalEventType",
+          "KeyName"
+        ],
+        "Text[]": [
+          "CustomEventData",
+          "ExternalEventData"
+        ],
+        "EMenuNavAction": [
+          "MenuNavAction"
+        ],
+        "Boolean": [
+          "IsActionAutoRepeat"
+        ],
+        "Integer": [
+          "KeyCode"
+        ]
+      }
+    },
+    "CManiaAppPlaygroundCommon": {
+      "props": {
+        "CManiaAppPlaygroundEvent[]": [
+          "PendingEvents"
+        ],
+        "CPlaygroundClient": [
+          "Playground"
+        ],
+        "CMap": [
+          "Map"
+        ],
+        "CUIConfig": [
+          "UI",
+          "ClientUI"
+        ]
+      }
+    },
+    "CManiaAppPlaygroundEvent": {
+      "props": {
+        "Text": [
+          "PlaygroundScriptEventType"
+        ],
+        "Text[]": [
+          "PlaygroundScriptEventData"
+        ]
+      }
+    },
+    "CManiaAppStation": {
+      "props": {
+        "CStation": [
+          "Station"
+        ],
+        "CPackCreatorTitleInfo[]": [
+          "Maker_EditedTitles"
+        ]
+      },
+      "methods": {
+        "EnterStation": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Maker_EditTitle": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "EditedTitleId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Maker_EditNewTitle": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "EditedTitleName"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [
@@ -3137,113 +3577,6 @@
           ],
           "returns": "Void"
         }
-      }
-    },
-    "CManiaApp": {
-      "props": {
-        "Integer": [
-          "Now"
-        ],
-        "Boolean": [
-          "IsVisible",
-          "EnableMenuNavigationInputs"
-        ],
-        "CUser": [
-          "LocalUser"
-        ],
-        "CTitle": [
-          "LoadedTitle"
-        ],
-        "Real": [
-          "MouseX",
-          "MouseY"
-        ],
-        "CUILayer[]": [
-          "UILayers"
-        ],
-        "CXmlManager": [
-          "Xml"
-        ],
-        "CHttpManager": [
-          "Http"
-        ],
-        "CAudioManager": [
-          "Audio"
-        ]
-      },
-      "methods": {
-        "UILayerCreate": {
-          "params": [],
-          "returns": "CUILayer"
-        },
-        "UILayerDestroy": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UILayerDestroyAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "LayerCustomEvent": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenLink": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "ELinkType",
-              "argument": "LinkType"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CManiaAppEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CUILayer": [
-          "CustomEventLayer"
-        ],
-        "Text": [
-          "CustomEventType",
-          "ExternalEventType",
-          "KeyName"
-        ],
-        "Text[]": [
-          "CustomEventData",
-          "ExternalEventData"
-        ],
-        "EMenuNavAction": [
-          "MenuNavAction"
-        ],
-        "Integer": [
-          "KeyCode"
-        ]
       }
     },
     "CManiaAppTitle": {
@@ -5267,29 +5600,6 @@
         ],
         "Ident": [
           "EditedAnchorDataId"
-        ]
-      }
-    },
-    "CMacroblockModel": {
-      "props": {
-        "Boolean": [
-          "IsGround",
-          "HasStart",
-          "HasFinish",
-          "HasCheckpoint"
-        ],
-        "CBlockModel": [
-          "GeneratedBlockModel"
-        ],
-        "Text": [
-          "Name"
-        ]
-      }
-    },
-    "CItemAnchor": {
-      "props": {
-        "Vec3": [
-          "Position"
         ]
       }
     },

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -3212,6 +3212,1036 @@
         }
       }
     },
+    "CManiaAppTitle": {
+      "props": {
+        "CManiaAppEvent[]": [
+          "PendingEvents"
+        ],
+        "Boolean": [
+          "LoadingScreenRequireKeyPressed",
+          "DontScaleMainMenuForHMD",
+          "Authentication_GetTokenResponseReceived"
+        ],
+        "CTitleFlow": [
+          "TitleFlow",
+          "TitleControl"
+        ],
+        "CTitleEdition": [
+          "TitleEdition"
+        ],
+        "CNotificationsConsumer": [
+          "Notifications"
+        ],
+        "Text": [
+          "ExternalRequest_Type",
+          "Authentication_Token"
+        ],
+        "Text[]": [
+          "ExternalRequest_Data"
+        ],
+        "CAchievementsManager": [
+          "AchievementsManager"
+        ],
+        "CBadgeManager": [
+          "BadgeManager"
+        ],
+        "CMatchSettingsManager": [
+          "MatchSettingsManager"
+        ],
+        "Integer": [
+          "Authentication_ErrorCode"
+        ]
+      },
+      "methods": {
+        "Menu_Quit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Home": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Solo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Local": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Internet": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Editor": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Profile": {
+          "params": [],
+          "returns": "Void"
+        },
+        "PlayMap": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Map"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ExternalRequest_Clear": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Authentication_GetToken": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "AppLogin"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CManiaAppTitleLayer": {
+      "props": {
+        "CManiaAppTitle": [
+          "ParentApp"
+        ],
+        "CTitleFlow": [
+          "TitleControl",
+          "TitleFlow"
+        ]
+      }
+    },
+    "CMap": {
+      "props": {
+        "CMapInfo": [
+          "MapInfo"
+        ],
+        "Text": [
+          "MapName",
+          "Comments",
+          "AuthorZoneIconUrl",
+          "CollectionName",
+          "DecorationName",
+          "AuthorLogin",
+          "AuthorNickName",
+          "AuthorZonePath",
+          "MapType",
+          "MapStyle",
+          "ObjectiveTextAuthor",
+          "ObjectiveTextGold",
+          "ObjectiveTextSilver",
+          "ObjectiveTextBronze"
+        ],
+        "Integer": [
+          "TMObjective_AuthorTime",
+          "TMObjective_GoldTime",
+          "TMObjective_SilverTime",
+          "TMObjective_BronzeTime",
+          "TMObjective_NbLaps",
+          "CopperPrice"
+        ],
+        "Boolean": [
+          "TMObjective_IsLapRace"
+        ],
+        "Int3": [
+          "Size"
+        ]
+      }
+    },
+    "CMapEditorPlugin": {
+      "props": {
+        "CMapEditorPluginEvent[]": [
+          "PendingEvents"
+        ],
+        "CMap": [
+          "Map"
+        ],
+        "Text": [
+          "MapName",
+          "ManialinkText"
+        ],
+        "PlaceMode": [
+          "PlaceMode"
+        ],
+        "EditMode": [
+          "EditMode"
+        ],
+        "Boolean": [
+          "IsEditorReadyForRequest",
+          "HoldLoadingScreen",
+          "IsUltraShadowsQualityAvailable",
+          "UndergroundMode",
+          "BlockStockMode",
+          "EnableAirMapping",
+          "EnableMixMapping",
+          "EnableEditorInputsCustomProcessing",
+          "EnableCursorShowingWhenInterfaceIsFocused",
+          "HideEditorInterface",
+          "HideBlockHelpers",
+          "ShowPlacementGrid",
+          "EditorInputIsDown_Menu",
+          "EditorInputIsDown_SwitchToRace",
+          "EditorInputIsDown_Undo",
+          "EditorInputIsDown_Redo",
+          "EditorInputIsDown_CursorUp",
+          "EditorInputIsDown_CursorRight",
+          "EditorInputIsDown_CursorDown",
+          "EditorInputIsDown_CursorLeft",
+          "EditorInputIsDown_CursorRaise",
+          "EditorInputIsDown_CursorLower",
+          "EditorInputIsDown_CursorTurn",
+          "EditorInputIsDown_CursorPick",
+          "EditorInputIsDown_CursorPlace",
+          "EditorInputIsDown_CursorDelete",
+          "EditorInputIsDown_CameraUp",
+          "EditorInputIsDown_CameraRight",
+          "EditorInputIsDown_CameraDown",
+          "EditorInputIsDown_CameraLeft",
+          "EditorInputIsDown_CameraZoomNext",
+          "EditorInputIsDown_Camera0",
+          "EditorInputIsDown_Camera1",
+          "EditorInputIsDown_Camera3",
+          "EditorInputIsDown_Camera7",
+          "EditorInputIsDown_Camera9",
+          "EditorInputIsDown_PivotChange",
+          "EditorInputIsDown_CursorTurnSlightly",
+          "EditorInputIsDown_CursorTurnSlightlyAntiClockwise",
+          "EditorInputIsDown_IconUp",
+          "EditorInputIsDown_IconRight",
+          "EditorInputIsDown_IconDown",
+          "EditorInputIsDown_IconLeft",
+          "EditorInputIsDown_RemoveAll",
+          "EditorInputIsDown_Save",
+          "EditorInputIsDown_SaveAs",
+          "EditorInputIsDown_MapStyle",
+          "EditorInputIsDown_ClassicMapEditor"
+        ],
+        "ShadowsQuality": [
+          "CurrentShadowsQuality"
+        ],
+        "Int3": [
+          "CursorCoord"
+        ],
+        "CardinalDirections": [
+          "CursorDir"
+        ],
+        "CBlockModel": [
+          "CursorBlockModel",
+          "CursorTerrainBlockModel"
+        ],
+        "CMacroblockModel": [
+          "CursorMacroblockModel"
+        ],
+        "Real": [
+          "CameraVAngle",
+          "CameraHAngle",
+          "CameraToTargetDistance",
+          "ThumbnailCameraVAngle",
+          "ThumbnailCameraHAngle",
+          "ThumbnailCameraRoll",
+          "ThumbnailCameraFovY",
+          "CursorBrightnessFactor",
+          "CollectionSquareSize",
+          "CollectionSquareHeight"
+        ],
+        "Vec3": [
+          "CameraTargetPosition",
+          "CameraPosition",
+          "ThumbnailCameraPosition",
+          "CustomSelectionRGB"
+        ],
+        "CItemAnchor[]": [
+          "Items"
+        ],
+        "Text[]": [
+          "MediatrackIngameClips",
+          "MediatrackIngameIsScriptClips"
+        ],
+        "Integer": [
+          "MediatrackIngameEditedClipIndex",
+          "CollectionGroundY"
+        ],
+        "CBlock[]": [
+          "Blocks"
+        ],
+        "CBlockModel[]": [
+          "BlockModels",
+          "TerrainBlockModels"
+        ],
+        "CMacroblockModel[]": [
+          "MacroblockModels"
+        ],
+        "CAnchorData[]": [
+          "AnchorData"
+        ],
+        "Int3[]": [
+          "CustomSelectionCoords"
+        ],
+        "ValidationStatus": [
+          "ValidationStatus"
+        ],
+        "CMlPage": [
+          "ManialinkPage"
+        ]
+      },
+      "methods": {
+        "ComputeShadows": {
+          "params": [],
+          "returns": "Void"
+        },
+        "DisplayDefaultSetObjectivesDialog": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Undo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Redo": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Help": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Validate": {
+          "params": [],
+          "returns": "Void"
+        },
+        "AutoSave": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Quit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "QuickQuit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "QuitAndSetResult": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Data"
+            }
+          ],
+          "returns": "Void"
+        },
+        "QuickQuitAndSetResult": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Data"
+            }
+          ],
+          "returns": "Void"
+        },
+        "TestMapFromStart": {
+          "params": [],
+          "returns": "Void"
+        },
+        "TestMapFromCoord": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Void"
+        },
+        "TestMapWithMode": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "RulesModeName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SaveMap": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetRaceCamera": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Yaw"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Pitch"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Roll"
+            },
+            {
+              "identifier": "Real",
+              "argument": "FovY"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveAllBlocks": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RemoveAllTerrain": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RemoveAllOffZone": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RemoveAllObjects": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RemoveAll": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RemoveAllBlocksAndTerrain": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ShowCustomSelection": {
+          "params": [],
+          "returns": "Void"
+        },
+        "HideCustomSelection": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyPaste_Copy": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyPaste_Cut": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyPaste_Remove": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyPaste_SelectAll": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyPaste_ResetSelection": {
+          "params": [],
+          "returns": "Void"
+        },
+        "OpenToolsMenu": {
+          "params": [],
+          "returns": "Void"
+        },
+        "EditMediatrackIngame": {
+          "params": [],
+          "returns": "Void"
+        },
+        "PreloadAllBlocks": {
+          "params": [],
+          "returns": "Void"
+        },
+        "PreloadAllItems": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CanPlaceBlock": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "OnGround"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "VariantIndex"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceBlock": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceBlock_NoDestruction": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "OnGround"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "VariantIndex"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceBlock_NoDestruction": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceRoadBlocks": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceRoadBlocks": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceTerrainBlocks": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceTerrainBlocks": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceTerrainBlocks_NoDestruction": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceMacroblock": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceMacroblock": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceMacroblock_NoDestruction": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceMacroblock_NoDestruction": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CanPlaceMacroblock_NoTerrain": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "PlaceMacroblock_NoTerrain": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveMacroblock": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveMacroblock_NoTerrain": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "GetBlock": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            }
+          ],
+          "returns": "CBlock"
+        },
+        "IsBlockModelSkinnable": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "GetNbBlockModelSkins": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetBlockModelSkin": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "SkinIndex"
+            }
+          ],
+          "returns": "Text"
+        },
+        "GetSkinDisplayName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "SkinFileName"
+            }
+          ],
+          "returns": "Text"
+        },
+        "GetBlockSkin": {
+          "params": [
+            {
+              "identifier": "CBlock",
+              "argument": "Block"
+            }
+          ],
+          "returns": "Text"
+        },
+        "SetBlockSkin": {
+          "params": [
+            {
+              "identifier": "CBlock",
+              "argument": "Block"
+            },
+            {
+              "identifier": "Text",
+              "argument": "SkinFileName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "OpenBlockSkinDialog": {
+          "params": [
+            {
+              "identifier": "CBlock",
+              "argument": "Block"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveBlock": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "Coord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveTerrainBlocks": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "GetBlockGroundHeight": {
+          "params": [
+            {
+              "identifier": "CBlockModel",
+              "argument": "BlockModel"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "CoordX"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "CoordZ"
+            },
+            {
+              "identifier": "CardinalDirections",
+              "argument": "Dir"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetGroundHeight": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "CoordX"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "CoordZ"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetMouseCoordOnGround": {
+          "params": [],
+          "returns": "Int3"
+        },
+        "GetMouseCoordAtHeight": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "CoordY"
+            }
+          ],
+          "returns": "Int3"
+        },
+        "GetStartLineBlock": {
+          "params": [],
+          "returns": "CBlock"
+        },
+        "RemoveItem": {
+          "params": [
+            {
+              "identifier": "CAnchorData",
+              "argument": "Item"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "CopyPaste_AddOrSubSelection": {
+          "params": [
+            {
+              "identifier": "Int3",
+              "argument": "StartCoord"
+            },
+            {
+              "identifier": "Int3",
+              "argument": "EndCoord"
+            }
+          ],
+          "returns": "Void"
+        },
+        "CopyPaste_Symmetrize": {
+          "params": [],
+          "returns": "Boolean"
+        },
+        "SaveMacroblock": {
+          "params": [
+            {
+              "identifier": "CMacroblockModel",
+              "argument": "MacroblockModel"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetMacroblockModelFromFilePath": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "MacroblockModelFilePath"
+            }
+          ],
+          "returns": "CMacroblockModel"
+        },
+        "GetTerrainBlockModelFromName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "TerrainBlockModelName"
+            }
+          ],
+          "returns": "CBlockModel"
+        },
+        "GetBlockModelFromName": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "BlockModelName"
+            }
+          ],
+          "returns": "CBlockModel"
+        },
+        "GetMapStyle": {
+          "params": [],
+          "returns": "Text"
+        },
+        "SetMapStyle": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "MapStyle"
+            }
+          ],
+          "returns": "Text"
+        }
+      }
+    },
+    "CMapEditorPluginEvent": {
+      "props": {
+        "Type": [
+          "Type"
+        ],
+        "EInput": [
+          "Input"
+        ],
+        "Ident": [
+          "EditedAnchorDataId"
+        ],
+        "Boolean": [
+          "IsFromPad",
+          "IsFromMouse",
+          "IsFromKeyboard",
+          "OnlyScriptMetadataModified"
+        ]
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [
@@ -3579,60 +4609,6 @@
         }
       }
     },
-    "CManiaAppTitle": {
-      "props": {
-        "CManiaAppEvent[]": [
-          "PendingEvents"
-        ],
-        "Boolean": [
-          "LoadingScreenRequireKeyPressed",
-          "DontScaleMainMenuForHMD"
-        ]
-      },
-      "methods": {
-        "Menu_Quit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Home": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Solo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Competitions": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Local": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Internet": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Editor": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Profile": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PlayMap": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Map"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
     "CStation": {
       "props": {
         "CTitle": [
@@ -3660,578 +4636,6 @@
         "EnterStation": {
           "params": [],
           "returns": "Void"
-        }
-      }
-    },
-    "CEditorPlugin": {
-      "props": {
-        "CEditorPluginEvent[]": [
-          "PendingEvents"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "Text": [
-          "MapName",
-          "ManialinkText"
-        ],
-        "PlaceMode": [
-          "PlaceMode"
-        ],
-        "EditMode": [
-          "EditMode"
-        ],
-        "Boolean": [
-          "UndergroundMode",
-          "BlockStockMode",
-          "EnableAirMapping",
-          "EnableMixMapping",
-          "EnableEditorInputsCustomProcessing",
-          "EditorInputIsDown_Menu",
-          "EditorInputIsDown_SwitchToRace",
-          "EditorInputIsDown_CursorUp",
-          "EditorInputIsDown_CursorRight",
-          "EditorInputIsDown_CursorDown",
-          "EditorInputIsDown_CursorLeft",
-          "EditorInputIsDown_CursorRaise",
-          "EditorInputIsDown_CursorLower",
-          "EditorInputIsDown_CursorTurn",
-          "EditorInputIsDown_CursorPick",
-          "EditorInputIsDown_CursorPlace",
-          "EditorInputIsDown_CursorDelete",
-          "EditorInputIsDown_CameraUp",
-          "EditorInputIsDown_CameraRight",
-          "EditorInputIsDown_CameraDown",
-          "EditorInputIsDown_CameraLeft",
-          "EditorInputIsDown_IconUp",
-          "EditorInputIsDown_IconRight",
-          "EditorInputIsDown_IconDown",
-          "EditorInputIsDown_IconLeft"
-        ],
-        "Int3": [
-          "CursorCoord"
-        ],
-        "CardinalDirections": [
-          "CursorDir"
-        ],
-        "CBlockModel": [
-          "CursorBlockModel",
-          "CursorTerrainBlockModel"
-        ],
-        "CMacroblockModel": [
-          "CursorMacroblockModel"
-        ],
-        "Real": [
-          "CameraVAngle",
-          "CameraHAngle",
-          "CameraToTargetDistance",
-          "CollectionSquareSize",
-          "CollectionSquareHeight"
-        ],
-        "Vec3": [
-          "TargetedPosition",
-          "CustomSelectionRGB"
-        ],
-        "CItemAnchor[]": [
-          "Items"
-        ],
-        "Text[]": [
-          "MediatrackIngameClips",
-          "MediatrackIngameIsScriptClips"
-        ],
-        "Integer": [
-          "MediatrackIngameEditedClipIndex",
-          "CollectionGroundY"
-        ],
-        "CBlock[]": [
-          "Blocks"
-        ],
-        "CBlockModel[]": [
-          "BlockModels",
-          "TerrainBlockModels"
-        ],
-        "CMacroblockModel[]": [
-          "MacroblockModels"
-        ],
-        "CAnchorData[]": [
-          "AnchorData"
-        ],
-        "Int3[]": [
-          "CustomSelectionCoords"
-        ],
-        "CMlPage": [
-          "ManialinkPage"
-        ]
-      },
-      "methods": {
-        "ComputeShadows": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Undo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Redo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Quit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Help": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Validate": {
-          "params": [],
-          "returns": "Void"
-        },
-        "AutoSave": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SaveMap": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            }
-          ],
-          "returns": "Void"
-        },
-        "RemoveAllBlocks": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllTerrain": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllOffZone": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllObjects": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllBlocksAndTerrain": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ShowCustomSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "HideCustomSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Copy": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Cut": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Remove": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_SelectAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_ResetSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "OpenToolsMenu": {
-          "params": [],
-          "returns": "Void"
-        },
-        "EditMediatrackIngame": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CanPlaceBlock": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "OnGround"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "VariantIndex"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceBlock": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceBlock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "OnGround"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "VariantIndex"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceBlock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceRoadBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceRoadBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceTerrainBlocks_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceMacroblock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceMacroblock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetBlock": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            }
-          ],
-          "returns": "CBlock"
-        },
-        "RemoveBlock": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetBlockGroundHeight": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "CoordX"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "CoordZ"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetStartLineBlock": {
-          "params": [],
-          "returns": "CBlock"
-        },
-        "CopyPaste_AddOrSubSelection": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CopyPaste_Symmetrize": {
-          "params": [],
-          "returns": "Boolean"
-        },
-        "SaveMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "MacroblockModel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetInterfaceNumber": {
-          "params": [
-            {
-              "identifier": "CCollector",
-              "argument": "Collector"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "SetInterfaceNumber": {
-          "params": [
-            {
-              "identifier": "CCollector",
-              "argument": "Collector"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "NewValue"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetMacroblockModelFromName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MacroblockModelName"
-            }
-          ],
-          "returns": "CMacroblockModel"
-        },
-        "GetTerrainBlockModelFromName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "TerrainBlockModelName"
-            }
-          ],
-          "returns": "CBlockModel"
-        },
-        "GetBlockModelFromName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BlockModelName"
-            }
-          ],
-          "returns": "CBlockModel"
         }
       }
     },
@@ -5536,43 +5940,6 @@
         }
       }
     },
-    "CMap": {
-      "props": {
-        "CMapInfo": [
-          "MapInfo"
-        ],
-        "Text": [
-          "MapName",
-          "Comments",
-          "AuthorZoneIconUrl",
-          "CollectionName",
-          "DecorationName",
-          "AuthorLogin",
-          "AuthorNickName",
-          "AuthorZonePath",
-          "MapType",
-          "MapStyle",
-          "ObjectiveTextAuthor",
-          "ObjectiveTextGold",
-          "ObjectiveTextSilver",
-          "ObjectiveTextBronze"
-        ],
-        "Integer": [
-          "TMObjective_AuthorTime",
-          "TMObjective_GoldTime",
-          "TMObjective_SilverTime",
-          "TMObjective_BronzeTime",
-          "TMObjective_NbLaps",
-          "CopperPrice"
-        ],
-        "Boolean": [
-          "TMObjective_IsLapRace"
-        ],
-        "Int3": [
-          "Size"
-        ]
-      }
-    },
     "CUILayer": {
       "props": {
         "Boolean": [
@@ -5587,19 +5954,6 @@
         ],
         "CMlPage": [
           "LocalPage"
-        ]
-      }
-    },
-    "CEditorPluginEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ],
-        "EInput": [
-          "Input"
-        ],
-        "Ident": [
-          "EditedAnchorDataId"
         ]
       }
     },

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -5192,23 +5192,6 @@
         ]
       }
     },
-    "CStation": {
-      "props": {
-        "CTitle": [
-          "Title"
-        ],
-        "Integer": [
-          "AudienceRegisteredUsers",
-          "CampaignMedalsMax",
-          "CampaignMedalsCurrent",
-          "CampaignMedalsRanking",
-          "LadderRank"
-        ],
-        "Real": [
-          "LadderPoints"
-        ]
-      }
-    },
     "CMlScriptIngame": {
       "props": {
         "Integer": [
@@ -7976,6 +7959,9 @@
           "UseDefaultActionEvents",
           "UseAllies",
           "UseAutoSpawnBots",
+          "UseAutoRespawnBots",
+          "WalkOnWall",
+          "UseAutoDiscardBotEvents",
           "ForceNavMapsComputation",
           "UseProtectClanmates"
         ],
@@ -8012,6 +7998,7 @@
           "MapLandmarks_Gauge",
           "MapLandmarks_Sector",
           "MapLandmarks_BotPath",
+          "MapLandmarks_BotSpawn",
           "MapLandmarks_ObjectAnchor",
           "MapLandmarks_Gate"
         ],
@@ -8572,6 +8559,786 @@
         }
       }
     },
+    "CSmModeEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CSmPlayer": [
+          "Player",
+          "Shooter",
+          "Victim"
+        ],
+        "Integer": [
+          "Damage",
+          "VictimShield",
+          "ShooterPoints",
+          "ShooterClan",
+          "WeaponNum",
+          "ShooterWeaponNum",
+          "VictimWeaponNum",
+          "CommandValueInteger",
+          "ActionChange"
+        ],
+        "CSmObject": [
+          "VictimObject",
+          "Object"
+        ],
+        "CModeTurret": [
+          "VictimTurret",
+          "ShooterTurret"
+        ],
+        "Real": [
+          "Height",
+          "MissDist",
+          "CommandValueReal"
+        ],
+        "Boolean": [
+          "ShooterUsedAction",
+          "VictimUsedAction",
+          "PlayerWasSpawned",
+          "PlayerWasInLadderMatch",
+          "GiveUp",
+          "CommandValueBoolean"
+        ],
+        "EActionSlot": [
+          "ShooterActionSlot",
+          "VictimActionSlot",
+          "Action_Slot"
+        ],
+        "Text": [
+          "ShooterActionId",
+          "VictimActionId",
+          "ActionId",
+          "Param1",
+          "CommandName",
+          "CommandValueText"
+        ],
+        "EActionInput": [
+          "ActionInput"
+        ],
+        "Text[]": [
+          "Param2"
+        ],
+        "CSmMapSector": [
+          "Sector"
+        ],
+        "CSmBlockPole": [
+          "BlockPole"
+        ],
+        "CSmMapLandmark": [
+          "Landmark"
+        ],
+        "CUser": [
+          "User"
+        ],
+        "Vec3": [
+          "PlayerLastPosition",
+          "PlayerLastAimDirection"
+        ]
+      }
+    },
+    "CSmObject": {
+      "props": {
+        "EStatus": [
+          "Status"
+        ],
+        "Ident": [
+          "ModelId"
+        ],
+        "CSmPlayer": [
+          "Player"
+        ],
+        "CSmMapLandmark": [
+          "AnchorLandmark"
+        ],
+        "Vec3": [
+          "Position",
+          "Vel"
+        ],
+        "Integer": [
+          "MachineState"
+        ],
+        "Boolean": [
+          "Throwable"
+        ]
+      },
+      "methods": {
+        "SetAnchor": {
+          "params": [
+            {
+              "identifier": "CSmMapObjectAnchor",
+              "argument": "ObjectAnchor"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetPlayer": {
+          "params": [
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetPosition": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetPositionAndVel": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Vel"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetUnspawned": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CSmPlayer": {
+      "props": {
+        "CSmScore": [
+          "Score"
+        ],
+        "ESpawnStatus": [
+          "SpawnStatus"
+        ],
+        "Integer": [
+          "StartTime",
+          "EndTime",
+          "CurWeapon",
+          "CurAmmo",
+          "CurAmmoMax",
+          "CurAmmoUnit",
+          "Armor",
+          "ArmorMax",
+          "ArmorGain",
+          "ArmorReplenishGain",
+          "Stamina",
+          "CurrentClan",
+          "IdleDuration"
+        ],
+        "Real": [
+          "AmmoGain",
+          "AmmoPower",
+          "ArmorPower",
+          "StaminaMax",
+          "StaminaGain",
+          "StaminaPower",
+          "SpeedPower",
+          "JumpPower",
+          "EnergyLevel",
+          "GetLinearHue",
+          "ForceLinearHue",
+          "ThrowSpeed",
+          "AimYaw",
+          "AimPitch",
+          "Speed"
+        ],
+        "Boolean": [
+          "AutoSwitchWeapon",
+          "AllowWallJump",
+          "AllowProgressiveJump",
+          "UseAlternateWeaponVisual",
+          "IsHighlighted",
+          "HasShield",
+          "IsInVehicle",
+          "IsUnderground",
+          "IsTouchingGround",
+          "IsInAir",
+          "IsOnTechGround",
+          "IsOnTechLaser",
+          "IsOnTechArrow",
+          "IsOnTechArmor",
+          "IsOnTechSafeZone",
+          "IsOnTech",
+          "IsOnTechNoWeapon",
+          "IsInWater",
+          "IsInOffZone",
+          "IsCapturing",
+          "IsFakePlayer",
+          "IsBot"
+        ],
+        "Vec3": [
+          "ForceColor",
+          "Position",
+          "AimDirection",
+          "Velocity"
+        ],
+        "Ident": [
+          "ForceModelId"
+        ],
+        "CSmMapLandmark": [
+          "CapturedLandmark"
+        ],
+        "CSmObject[]": [
+          "Objects"
+        ],
+        "CSmPlayerDriver": [
+          "Driver"
+        ]
+      }
+    },
+    "CSmPlayerDriver": {
+      "props": {
+        "ESmDriverBehaviour": [
+          "Behaviour"
+        ],
+        "Real": [
+          "AggroRadius",
+          "ShootRadius",
+          "TargetMinDistance",
+          "DisengageDistance",
+          "PathSpeedCoef",
+          "Accuracy",
+          "Fov",
+          "Agressivity",
+          "Escape_DistanceSafe",
+          "Escape_DistanceMinEscape",
+          "Escape_DistanceMaxEscape",
+          "Saunter_Radius"
+        ],
+        "Integer": [
+          "ReactionTime",
+          "ShootPeriodMin",
+          "ShootPeriodMax",
+          "PathOffset",
+          "Saunter_BaseChillingTime",
+          "Saunter_ChillingTimeDelta"
+        ],
+        "Boolean": [
+          "RocketAnticipation",
+          "IsStuck",
+          "IsFlying",
+          "UseOldShootingSystem",
+          "Scripted_ForceAimInMoveDir"
+        ],
+        "ESmAttackFilter": [
+          "AttackFilter"
+        ],
+        "CSmPlayer": [
+          "Target",
+          "Owner",
+          "ForcedTarget"
+        ],
+        "ESmDriverPatrolMode": [
+          "Patrol_Mode"
+        ],
+        "Vec3": [
+          "Escape_AnchorPoint",
+          "Saunter_AnchorPoint"
+        ],
+        "CSmPlayer[]": [
+          "TargetsToAvoid"
+        ]
+      }
+    },
+    "CSmScore": {
+      "props": {
+        "Integer": [
+          "TeamNum",
+          "Points",
+          "RoundPoints",
+          "NbEliminationsInflicted",
+          "NbEliminationsTaken",
+          "NbRespawnsRequested",
+          "DamageInflicted",
+          "DamageTaken"
+        ]
+      },
+      "methods": {
+        "Clear": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CSmSector": {
+      "props": {
+        "Ident[]": [
+          "PlayersIds"
+        ]
+      }
+    },
+    "CStation": {
+      "props": {
+        "CTitle": [
+          "Title"
+        ],
+        "Integer": [
+          "AudienceRegisteredUsers",
+          "CampaignMedalsMax",
+          "CampaignMedalsCurrent",
+          "CampaignMedalsRanking",
+          "LadderRank",
+          "NextEchelonPercent"
+        ],
+        "Real": [
+          "LadderPoints",
+          "GhostAlpha"
+        ],
+        "EEchelon": [
+          "Echelon"
+        ],
+        "Boolean": [
+          "DisableQuickEnter",
+          "IsLogoVisible",
+          "IsEditable"
+        ],
+        "Vec3": [
+          "FocusLightColor",
+          "NormalLightColor"
+        ]
+      }
+    },
+    "CTaskResult": {
+      "props": {
+        "Ident": [
+          "Id"
+        ],
+        "Boolean": [
+          "IsProcessing",
+          "HasSucceeded",
+          "HasFailed",
+          "IsCanceled"
+        ],
+        "ETaskErrorType": [
+          "ErrorType"
+        ],
+        "Integer": [
+          "ErrorCode"
+        ],
+        "Text": [
+          "ErrorDescription"
+        ]
+      },
+      "methods": {
+        "Cancel": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CTaskResult_BuddiesChallengeRecord": {
+      "props": {
+        "Text": [
+          "Login"
+        ],
+        "CHighScoreComparison[]": [
+          "BuddiesChallengeRecord"
+        ]
+      },
+      "methods": {
+        "SortByOpponentCount": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentDisplayName": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentLogin": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentRecordDate": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentRecordTime": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CTaskResult_BuddiesChallengeRecordsComparison": {
+      "props": {
+        "Text": [
+          "Login"
+        ],
+        "CHighScoreComparisonSummary[]": [
+          "BuddiesChallengeRecord"
+        ]
+      },
+      "methods": {
+        "SortByPlayerCount": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentLogin": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentCount": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentDate": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByOpponentDisplayName": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CTaskResult_BuddyChallengeRecordsComparison": {
+      "props": {
+        "Text": [
+          "Login",
+          "BuddyLogin"
+        ],
+        "CHighScoreComparison[]": [
+          "PlayerBestRecordsComparison",
+          "BuddyBestRecordsComparison"
+        ]
+      },
+      "methods": {
+        "SortByMapName": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByReccordTime": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByReccordTimeDiff": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SortByReccordDate": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CTaskResult_CheckTargetedPrivilege": {
+      "methods": {
+        "AddLogin": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            }
+          ],
+          "returns": "Void"
+        },
+        "StartTask": {
+          "params": [],
+          "returns": "Void"
+        },
+        "HasPrivilege": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "GetDenyReason": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            }
+          ],
+          "returns": "Text"
+        }
+      }
+    },
+    "CTaskResult_FileList": {
+      "props": {
+        "Text": [
+          "ParentPath",
+          "Path"
+        ],
+        "Text[]": [
+          "Files",
+          "SubFolders"
+        ]
+      }
+    },
+    "CTaskResult_GameModeList": {
+      "props": {
+        "CGameModeInfo[]": [
+          "GamesModes"
+        ]
+      }
+    },
+    "CTaskResult_GetOnlinePresence": {
+      "props": {
+        "COnlinePresence[]": [
+          "OnlinePresences"
+        ]
+      },
+      "methods": {
+        "AddLogin": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            }
+          ],
+          "returns": "Void"
+        },
+        "StartTask": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CTaskResult_Ghost": {
+      "props": {
+        "CGhost": [
+          "Ghost"
+        ]
+      }
+    },
+    "CTaskResult_GhostList": {
+      "props": {
+        "CGhost[]": [
+          "Ghosts"
+        ]
+      }
+    },
+    "CTaskResult_MapList": {
+      "props": {
+        "Text": [
+          "ParentPath",
+          "Path"
+        ],
+        "CMapInfo[]": [
+          "MapInfos"
+        ],
+        "Text[]": [
+          "SubFolders"
+        ]
+      }
+    },
+    "CTaskResult_NaturalLeaderBoardInfoList": {
+      "props": {
+        "Integer": [
+          "FromIndex",
+          "Count"
+        ],
+        "CNaturalLeaderBoardInfo[]": [
+          "LeaderBoardInfo"
+        ]
+      }
+    },
+    "CTaskResult_RealLeaderBoardInfoList": {
+      "props": {
+        "Integer": [
+          "FromIndex",
+          "Count"
+        ],
+        "CRealLeaderBoardInfo[]": [
+          "LeaderBoardInfo"
+        ]
+      }
+    },
+    "CTaskResult_ReplayList": {
+      "props": {
+        "Text": [
+          "ParentPath",
+          "Path"
+        ],
+        "CReplayInfo[]": [
+          "ReplayInfos"
+        ],
+        "Text[]": [
+          "SubFolders"
+        ]
+      }
+    },
+    "CTaskResult_StringIntList": {
+      "props": {
+        "Text[]": [
+          "Values"
+        ]
+      }
+    },
+    "CTeam": {
+      "props": {
+        "Text": [
+          "Name",
+          "ZonePath",
+          "City",
+          "EmblemUrl",
+          "PresentationManialinkUrl",
+          "ClubLinkUrl",
+          "ColorText",
+          "ColorizedName"
+        ],
+        "Vec3": [
+          "ColorPrimary",
+          "ColorSecondary"
+        ]
+      }
+    },
+    "CTitle": {
+      "props": {
+        "Text": [
+          "TitleId",
+          "AuthorLogin",
+          "AuthorName",
+          "Name",
+          "Desc",
+          "InfoUrl",
+          "DownloadUrl",
+          "TitleVersion",
+          "MakerTitleId",
+          "BaseTitleId"
+        ]
+      }
+    },
+    "CTitleEdition": {
+      "props": {
+        "CTitle": [
+          "TitleMaker"
+        ],
+        "CPackCreator": [
+          "PackCreator"
+        ],
+        "Text": [
+          "EditedTitleId"
+        ],
+        "CPackCreatorTitleInfo": [
+          "EditedTitleInfo"
+        ],
+        "Boolean": [
+          "Dialog_IsFinished",
+          "Dialog_Success",
+          "Dialog_Aborted"
+        ]
+      },
+      "methods": {
+        "File_ImportFromUser": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "File_Move": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "OrigName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "DestNameOrFolder"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "KeepOriginalCopy"
+            }
+          ],
+          "returns": "Void"
+        },
+        "File_Exists": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            },
+            {
+              "identifier": "EDrive",
+              "argument": "InDrive"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "File_Delete": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "File_WriteText": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Text"
+            }
+          ],
+          "returns": "Void"
+        },
+        "File_ReadText": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Text"
+        },
+        "Dialog_ImportFiles": {
+          "params": [],
+          "returns": "Void"
+        },
+        "OpenTitleFolderInExplorer": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ReloadTitleDesc": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SaveTitleDesc": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetTitleCampaign": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "CampaignNum"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ScoreContext"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapsFolderNameOrPlayListName"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "OfficialRecordEnabled"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
     "CTmMlScriptIngame": {
       "props": {
         "CTmMlPlayer": [
@@ -8813,19 +9580,6 @@
         ]
       }
     },
-    "CTitle": {
-      "props": {
-        "Text": [
-          "TitleId",
-          "BaseTitleId",
-          "Name",
-          "Desc",
-          "InfoUrl",
-          "DownloadUrl",
-          "TitleVersion"
-        ]
-      }
-    },
     "CXmlManager": {
       "props": {
         "CXmlDocument[]": [
@@ -8882,252 +9636,7 @@
         ]
       }
     },
-    "CSmPlayer": {
-      "props": {
-        "CSmScore": [
-          "Score"
-        ],
-        "ESpawnStatus": [
-          "SpawnStatus"
-        ],
-        "Integer": [
-          "StartTime",
-          "EndTime",
-          "CurWeapon",
-          "CurAmmo",
-          "CurAmmoMax",
-          "CurAmmoUnit",
-          "Armor",
-          "ArmorMax",
-          "ArmorGain",
-          "ArmorReplenishGain",
-          "Stamina",
-          "CurrentClan",
-          "IdleDuration"
-        ],
-        "Real": [
-          "AmmoGain",
-          "AmmoPower",
-          "ArmorPower",
-          "StaminaMax",
-          "StaminaGain",
-          "StaminaPower",
-          "SpeedPower",
-          "JumpPower",
-          "EnergyLevel",
-          "ThrowSpeed",
-          "AimYaw",
-          "AimPitch",
-          "Speed"
-        ],
-        "Boolean": [
-          "AutoSwitchWeapon",
-          "AllowWallJump",
-          "AllowProgressiveJump",
-          "UseAlternateWeaponVisual",
-          "IsHighlighted",
-          "HasShield",
-          "IsUnderground",
-          "IsTouchingGround",
-          "IsInAir",
-          "IsOnTechGround",
-          "IsOnTechLaser",
-          "IsOnTechArrow",
-          "IsOnTechArmor",
-          "IsOnTechSafeZone",
-          "IsOnTech",
-          "IsOnTechNoWeapon",
-          "IsInWater",
-          "IsInOffZone",
-          "IsCapturing",
-          "IsFakePlayer",
-          "IsBot"
-        ],
-        "Vec3": [
-          "ForceColor",
-          "Position",
-          "AimDirection",
-          "Velocity"
-        ],
-        "Ident": [
-          "ForceModelId"
-        ],
-        "CSmMapLandmark": [
-          "CapturedLandmark"
-        ],
-        "CSmObject[]": [
-          "Objects"
-        ],
-        "CSmPlayerDriver": [
-          "Driver"
-        ]
-      }
-    },
-    "CSmModeEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CSmPlayer": [
-          "Player",
-          "Shooter",
-          "Victim"
-        ],
-        "Integer": [
-          "Damage",
-          "ShooterPoints",
-          "WeaponNum",
-          "ShooterWeaponNum",
-          "VictimWeaponNum",
-          "CommandValueInteger",
-          "ActionChange"
-        ],
-        "CSmObject": [
-          "VictimObject",
-          "Object"
-        ],
-        "Real": [
-          "Height",
-          "MissDist",
-          "CommandValueReal"
-        ],
-        "Boolean": [
-          "ShooterUsedAction",
-          "VictimUsedAction",
-          "PlayerWasSpawned",
-          "PlayerWasInLadderMatch",
-          "GiveUp",
-          "CommandValueBoolean"
-        ],
-        "EActionSlot": [
-          "ShooterActionSlot",
-          "VictimActionSlot",
-          "Action_Slot"
-        ],
-        "Text": [
-          "ShooterActionId",
-          "VictimActionId",
-          "ActionId",
-          "Param1",
-          "CommandName",
-          "CommandValueText"
-        ],
-        "EActionInput": [
-          "ActionInput"
-        ],
-        "Text[]": [
-          "Param2"
-        ],
-        "CSmMapSector": [
-          "Sector"
-        ],
-        "CSmBlockPole": [
-          "BlockPole"
-        ],
-        "CSmMapLandmark": [
-          "Landmark"
-        ],
-        "Ident": [
-          "PlayerId"
-        ],
-        "CUser": [
-          "User"
-        ],
-        "Vec3": [
-          "PlayerLastPosition",
-          "PlayerLastAimDirection"
-        ]
-      }
-    },
-    "CSmScore": {
-      "props": {
-        "Integer": [
-          "TeamNum",
-          "Points",
-          "RoundPoints",
-          "NbEliminationsInflicted",
-          "NbEliminationsTaken",
-          "NbRespawnsRequested",
-          "DamageInflicted",
-          "DamageTaken"
-        ]
-      },
-      "methods": {
-        "Clear": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CSmObject": {
-      "props": {
-        "EStatus": [
-          "Status"
-        ],
-        "Ident": [
-          "ModelId"
-        ],
-        "CSmPlayer": [
-          "Player"
-        ],
-        "Vec3": [
-          "Position",
-          "Vel"
-        ],
-        "Integer": [
-          "MachineState"
-        ],
-        "Boolean": [
-          "Throwable"
-        ]
-      },
-      "methods": {
-        "SetAnchor": {
-          "params": [
-            {
-              "identifier": "CSmMapObjectAnchor",
-              "argument": "ObjectAnchor"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPosition": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPositionAndVel": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Vel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetUnspawned": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
+
     "CTmMlPlayer": {
       "props": {
         "Integer": [
@@ -9296,24 +9805,6 @@
         }
       }
     },
-    "CTeam": {
-      "props": {
-        "Text": [
-          "Name",
-          "ZonePath",
-          "City",
-          "EmblemUrl",
-          "PresentationManialinkUrl",
-          "ClubLinkUrl",
-          "ColorText",
-          "ColorizedName"
-        ],
-        "Vec3": [
-          "ColorPrimary",
-          "ColorSecondary"
-        ]
-      }
-    },
     "CUIConfigMgr": {
       "props": {
         "CUIConfig": [
@@ -9406,58 +9897,6 @@
         }
       }
     },
-    "CSmPlayerDriver": {
-      "props": {
-        "ESmDriverBehaviour": [
-          "Behaviour"
-        ],
-        "Real": [
-          "AggroRadius",
-          "DisengageDistance",
-          "PathSpeedCoef",
-          "Accuracy",
-          "Fov",
-          "Agressivity",
-          "Escape_DistanceSafe",
-          "Escape_DistanceMinEscape",
-          "Escape_DistanceMaxEscape",
-          "Saunter_Radius"
-        ],
-        "Integer": [
-          "ReactionTime",
-          "ShootPeriodMin",
-          "ShootPeriodMax",
-          "PathOffset",
-          "Saunter_BaseChillingTime",
-          "Saunter_ChillingTimeDelta"
-        ],
-        "Boolean": [
-          "RocketAnticipation",
-          "IsStuck",
-          "IsFlying",
-          "UseOldShootingSystem",
-          "Scripted_ForceAimInMoveDir"
-        ],
-        "ESmAttackFilter": [
-          "AttackFilter"
-        ],
-        "CSmPlayer": [
-          "Target",
-          "ForcedTarget"
-        ],
-        "ESmDriverPatrolMode": [
-          "Patrol_Mode"
-        ],
-        "Vec3": [
-          "Escape_AnchorPoint",
-          "Saunter_AnchorPoint"
-        ],
-        "CSmPlayer[]": [
-          "TargetsToAvoid"
-        ]
-      }
-    },
-
     "CUIConfig": {
       "props": {
         "EUISequence": [
@@ -9759,13 +10198,6 @@
         ],
         "Text[]": [
           "ParamArray2"
-        ]
-      }
-    },
-    "CSmSector": {
-      "props": {
-        "Ident[]": [
-          "PlayersIds"
         ]
       }
     },

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -702,6 +702,232 @@
         ]
       }
     },
+    "CDataFileMgr": {
+      "props": {
+        "CTaskResult[]": [
+          "TaskResults"
+        ],
+        "CCampaign[]": [
+          "Campaigns"
+        ],
+        "CGhost[]": [
+          "Ghosts"
+        ]
+      },
+      "methods": {
+        "TaskResult_Release": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TaskId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Campaign_Get": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            }
+          ],
+          "returns": "CCampaign"
+        },
+        "Map_RefreshFromDisk": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Map_GetUserList": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "returns": "CTaskResult_MapList"
+        },
+        "Map_GetGameList": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_MapList"
+        },
+        "Map_GetFilteredGameList": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Scope"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_MapList"
+        },
+        "Ghost_Release": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "GhostId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ghost_Download": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "CTaskResult_Ghost"
+        },
+        "Replay_RefreshFromDisk": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Replay_GetGameList": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_ReplayList"
+        },
+        "Replay_GetFilteredGameList": {
+          "params": [
+            {
+              "identifier" : "Integer",
+              "argument": "Scope"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_ReplayList"
+        },
+        "Replay_Load": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            }
+          ],
+          "returns": "CTaskResult_GhostList"
+        },
+        "Replay_Save": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "CMap",
+              "argument": "Map"
+            },
+            {
+              "identifier": "CGhost",
+              "argument": "Ghost"
+            }
+          ],
+          "returns": "CTaskResult"
+        },
+        "Media_GetGameList": {
+          "params": [
+            {
+              "identifier": "EMediaType",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_FileList"
+        },
+        "Media_GetFilteredGameList": {
+          "params": [
+            {
+              "identifier": "EMediaType",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Scope"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_FileList"
+        },
+        "GameMode_GetGameList": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Scope"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Path"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Flatten"
+            }
+          ],
+          "returns": "CTaskResult_GameModeList"
+        },
+        "Pack_DownloadOrUpdate": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "DisplayName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "CTaskResult"
+        }
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -6132,6 +6132,1266 @@
         }
       }
     },
+    "CModulePlaygroundStore": {
+      "methods": {
+        "Reset": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetMoney": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Amount"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetMoney": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "AddMoney": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Amount"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "SubMoney": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Amount"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "SetActionLevel": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ActionUrl"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "ActionLevel"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetActionLevel": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ActionUrl"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "SetItemCanBeBought": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ActionUrl"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "CanBeBought"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetItemCanBeBought": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ActionUrl"
+            }
+          ],
+          "returns": "Boolean"
+        }
+      }
+    },
+    "CNaturalLeaderBoardInfo": {
+      "props": {
+        "Integer": [
+          "Rank",
+          "Score"
+        ],
+        "Ident": [
+          "UserId"
+        ],
+        "Text": [
+          "Login",
+          "DisplayName",
+          "FileName",
+          "ReplayUrl"
+        ]
+      }
+    },
+    "CNod": {
+      "props": {
+        "Ident": [
+          "Id"
+        ]
+      }
+    },
+    "CNotificationsConsumer": {
+      "props": {
+        "CNotificationsConsumerEvent[]": [
+          "Events"
+        ],
+        "CNotificationsConsumerNotification[]": [
+          "Notifications",
+          "FilteredNotifications"
+        ],
+        "EFilterPriority": [
+          "Filter_Priority"
+        ]
+      }
+    },
+    "CNotificationsConsumerEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CNotificationsConsumerNotification": [
+          "Notification"
+        ]
+      }
+    },
+    "CNotificationsConsumerNotification": {
+      "props": {
+        "Text": [
+          "Title",
+          "Description",
+          "ImageUrl"
+        ],
+        "ENotificationPriority": [
+          "Priority"
+        ],
+        "Boolean": [
+          "HasBeenRead",
+          "HasBeenActivated"
+        ]
+      },
+      "methods": {
+        "SetRead": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetActivated": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "COnlinePresence": {
+      "props": {
+        "Text": [
+          "Login",
+          "DisplayName",
+          "ServerLogin"
+        ],
+        "Boolean": [
+          "IsOnline"
+        ]
+      }
+    },
+    "CPackCreator": {
+      "props": {
+        "Boolean": [
+          "RegisterPack_IsInProgess"
+        ],
+        "CPackCreatorPack": [
+          "CurrentPack"
+        ]
+      },
+      "methods": {
+        "RegisterPackForEditedTitle": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Build_Begin": {
+          "params": [
+            {
+              "identifier": "CPackCreatorPack",
+              "argument": "Pack"
+            },
+            {
+              "identifier": "CPackCreatorTitleInfo",
+              "argument": "TitleInfo"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Build_AddFile": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "FileName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Build_AddFolder": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "FolderName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Build_Generate": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Upload"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Build_IsGenerated": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Build_ErrorMessage": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Build_End": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "BuildId"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CPackCreatorPack": {
+      "props": {
+        "Ident": [
+          "PackId",
+          "CreatorId"
+        ],
+        "Boolean": [
+          "IsTitlePack"
+        ],
+        "CPackCreatorRecipient[]": [
+          "Recipients"
+        ]
+      },
+      "methods": {
+        "Recipients_Add": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "UseCost"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "GetCost"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Recipients_Remove": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Login"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CPackCreatorRecipient": {
+      "props": {
+        "Text": [
+          "Login"
+        ],
+        "Integer": [
+          "GetCost",
+          "UseCost"
+        ]
+      }
+    },
+    "CPackCreatorTitleInfo": {
+      "props": {
+        "Ident": [
+          "TitleId",
+          "MakerTitleId"
+        ],
+        "Text": [
+          "DisplayName",
+          "Description",
+          "InfoUrl",
+          "DownloadUrl",
+          "TitleVersion",
+          "AllowedClientTitleVersion",
+          "BaseTitleIds",
+          "ForcedPlayerModel",
+          "Packaging_ImageFileName",
+          "Packaging_LogosFileName",
+          "Packaging_Group",
+          "Station_ManialinkUrl",
+          "Menus_BgReplayFileName",
+          "Menus_ManiaAppFileName",
+          "Menus_MusicFileName",
+          "Hud3dFontFileName",
+          "MusicFolder"
+        ],
+        "Boolean": [
+          "Solo_HasCampaign"
+        ]
+      }
+    },
+    "CPlayer": {
+      "props": {
+        "CUser": [
+          "User"
+        ],
+        "Integer": [
+          "RequestedClan"
+        ],
+        "Boolean": [
+          "RequestsSpectate"
+        ]
+      }
+    },
+    "CPlaygroundClient": {
+      "props": {
+        "CMap": [
+          "Map"
+        ],
+        "Integer": [
+          "GameTime"
+        ],
+        "CUser": [
+          "LocalUser"
+        ],
+        "CUIConfig": [
+          "UI"
+        ],
+        "CServerInfo": [
+          "ServerInfo"
+        ],
+        "Boolean": [
+          "IsSpectator",
+          "IsSpectatorClient",
+          "UseClans",
+          "UseForcedClans",
+          "IsLoadingScreen",
+          "DisablePlayingStateTracking"
+        ],
+        "CTeam[]": [
+          "Teams"
+        ]
+      },
+      "methods": {
+        "QuitServer": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "Silent"
+            }
+          ],
+          "returns": "Void"
+        },
+        "QuitServerAndSetResult": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "Silent"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Type"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Data"
+            }
+          ],
+          "returns": "Void"
+        },
+        "JoinTeam1": {
+          "params": [],
+          "returns": "Void"
+        },
+        "JoinTeam2": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestSpectatorClient": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "Spectator"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SepSpectateTarget": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ShowProfile": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CPresenceMgr": {
+      "props": {
+        "CTaskResult[]": [
+          "TaskResults"
+        ]
+      },
+      "methods": {
+        "ReleaseTaskResult": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TaskId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetPresence": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "ERichPresence",
+              "argument": "UplayFlow"
+            }
+          ],
+          "returns": "Void"
+        },
+        "GetOnlinePresenceForPlayers": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "returns": "CTaskResult_GetOnlinePresence"
+        }
+      }
+    },
+    "CPrivilegeMgr": {
+      "props": {
+        "CTaskResult[]": [
+          "TaskResults"
+        ]
+      },
+      "methods": {
+        "ReleaseTaskResult": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TaskId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "CheckPrivilege": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "EPrivilege",
+              "argument": "Privilege"
+            }
+          ],
+          "returns": "CTaskResult"
+        },
+        "CheckPrivilegeForAllUsers": {
+          "params": [
+            {
+              "identifier": "EPrivilege",
+              "argument": "Privilege"
+            }
+          ],
+          "returns": "CTaskResult"
+        },
+        "CheckTargetedPrivilege": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "EPrivilege",
+              "argument": "Privilege"
+            }
+          ],
+          "returns": "CTaskResult_CheckTargetedPrivilege"
+        },
+        "CheckTargetedPrivilegeForAllUsers": {
+          "params": [
+            {
+              "identifier": "EPrivilege",
+              "argument": "Privilege"
+            }
+          ],
+          "returns": "CTaskResult_CheckTargetedPrivilege"
+        }
+      }
+    },
+    "CRealLeaderBoardInfo": {
+      "props": {
+        "Integer": [
+          "Rank"
+        ],
+        "Ident": [
+          "UserId"
+        ],
+        "Text": [
+          "Login",
+          "DisplayName",
+          "FileName",
+          "ReplayUrl"
+        ],
+        "Real": [
+          "Score"
+        ]
+      }      
+    },
+    "CReplayInfo": {
+      "props": {
+        "Text": [
+          "MapUid",
+          "Name",
+          "Path",
+          "FileName"
+        ]
+      }
+    },
+    "CScore": {
+      "props": {
+        "CUser": [
+          "User"
+        ],
+        "Boolean": [
+          "IsRegisteredForLadderMatch"
+        ],
+        "Real": [
+          "LadderScore",
+          "LadderMatchScoreValue"
+        ],
+        "Integer": [
+          "LadderRankSortValue",
+          "LadderClan"
+        ]
+      }
+    },
+    "CScoreMgr": {
+      "props": {
+        "CTaskResult[]": [
+          "TaskResults"
+        ]
+      },
+      "methods": {
+        "TaskResult_Release": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "TaskId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ScoreStatus_GetLocalStatus": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "returns": "ELocalScoreStatus"
+        },
+        "ScoreStatus_GetMasterServerStatus": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            }
+          ],
+          "returns": "EMasterServerScoreStatus"
+        },
+        "Playground_GetPlayerGhost": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "GamePlayer"
+            }
+          ],
+          "returns": "CGhost"
+        },
+        "Map_SetNewRecord": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "CGhost",
+              "argument": "Ghost"
+            }
+          ],
+          "returns": "CTaskResult"
+        },
+        "Map_GetRecord": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Map_GetRecordGhost": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            }
+          ],
+          "returns": "CTaskResult_Ghost"
+        },
+        "Map_GetMultiAsyncLevel": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Map_GetMultiAsyncLevelRecord": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "MultiAsyncLevel"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Map_GetMultiAsyncLevelRecordGhost": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "MultiAsyncLevel"
+            }
+          ],
+          "returns": "CTaskResult_Ghost"
+        },
+        "Map_GetSkillPoints": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "MapLeaderBoard_GetPlayerRanking": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "MapLeaderBoard_GetPlayerCount": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "MapLeaderBoard_GetPlayerList": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Context"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "FromIndex"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Count"
+            }
+          ],
+          "returns": "CTaskResult_NaturalLeaderBoardInfoList"
+        },
+        "Campaign_GetMultiAsyncLevel": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Campaign_GetMultiAsyncLevelCount": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "MultiAsyncLevel"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Campaign_GetSkillPoints": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Campaign_GetOpponentRecords": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "OpponentLogin"
+            }
+          ],
+          "returns": "CWebServicesTaskResult_MapRecordListScript"
+        },
+        "Campaign_GetBuddiesMapRecord": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            }
+          ],
+          "returns": "CTaskResult_BuddiesChallengeRecord"
+        },
+        "Campaign_IsBuddiesMapRecordDirty": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "MapUid"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Campaign_GetBuddiesMapRecordsComparison": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            }
+          ],
+          "returns": "CTaskResult_BuddiesChallengeRecordsComparison"
+        },
+        "Campaign_GetBuddyMapRecordsComparison": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "OpponentLogin"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            }
+          ],
+          "returns": "CTaskResult_BuddyChallengeRecordsComparison"
+        },
+        "CampaignLeaderBoard_GetPlayerRanking": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "UseSkillPoints"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "CampaignLeaderBoard_GetPlayerCount": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "UseSkillPoints"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "CampaignLeaderBoard_GetPlayerList": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "CampaignId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "UseSkillPoints"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "FromIndex"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Count"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Multiplayer_AddToScore": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Real",
+              "argument": "ScoreDiff"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Timestamp"
+            }
+          ],
+          "returns": "Void"
+        },
+        "MultiplayerLeaderBoard_GetPlayerRanking": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "MultiplayerLeaderBoard_GetPlayerCount": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GlobalLeaderBoard_GetPlayerRanking": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GlobalLeaderBoard_GetPlayerCount": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GlobalLeaderBoard_GetPlayerList": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "UserId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Zone"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "FromIndex"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Count"
+            }
+          ],
+          "returns": "CTaskResult_RealLeaderBoardInfoList"
+        }
+      }
+    },
+    "CServerAdmin": {
+      "props": {
+        "CServerInfo": [
+          "ServerInfo"
+        ]
+      },
+      "methods": {
+        "AutoTeamBalance": {
+          "params": [],
+          "returns": "Void"
+        },
+        "KickUser": {
+          "params": [
+            {
+              "identifier": "CUser",
+              "argument": "User"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Reason"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "SetLobbyInfo": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "IsLobby"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "LobbyPlayerCount"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "LobbyMaxPlayerCount"
+            },
+            {
+              "identifier": "Real",
+              "argument": "LobbyPlayerLevel"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SendToServerAfterMatch": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ServerUrl"
+            }
+          ],
+          "returns": "Void"
+        },
+        "CustomizeQuitDialog": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ManialinkPage"
+            },
+            {
+              "identifier": "Text",
+              "argument": "SendToServerUrl"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "ProposeAddToFavorites"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "ForceDelay"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CServerInfo": {
+      "props": {
+        "Text": [
+          "ServerName",
+          "ServerLogin",
+          "JoinLink",
+          "Comment",
+          "ServerVersionBuild",
+          "ServerLevelText",
+          "ModeName",
+          "SendToServerAfterMatchUrl"
+        ],
+        "Integer": [
+          "PlayerCount",
+          "MaxPlayerCount",
+          "SpectatorCount",
+          "MaxSpectatorCount",
+          "ServerLevel",
+          "NbChallenges"
+        ],
+        "Real": [
+          "PlayersLevelMin",
+          "PlayersLevelAvg",
+          "PlayersLevelMax",
+          "LadderServerLimitMax",
+          "LadderServerLimitMin"
+        ],
+        "Text[]": [
+          "PlayerNames",
+          "ChallengeNames"
+        ],
+        "Boolean": [
+          "HasBuddies",
+          "IsFavourite",
+          "IsLobbyServer",
+          "IsPrivate",
+          "IsPrivateForSpectator"
+        ]
+      }
+    },
     "CSmMode": {
       "props": {
         "Integer": [
@@ -7145,10 +8405,6 @@
         ]
       }
     },
-    "CNod": {
-      "props": {},
-      "methods": {}
-    },
     "CUser": {
       "props": {
         "Text": [
@@ -7863,23 +9119,6 @@
         }
       }
     },
-    "CPlayer": {
-      "props": {
-        "CUser": [
-          "User"
-        ],
-        "Text": [
-          "Login",
-          "Name"
-        ],
-        "Integer": [
-          "RequestedClan"
-        ],
-        "Boolean": [
-          "RequestsSpectate"
-        ]
-      }
-    },
     "CSmPlayerDriver": {
       "props": {
         "ESmDriverBehaviour": [
@@ -8002,24 +9241,6 @@
         ],
         "Ident": [
           "ItemModelId"
-        ]
-      }
-    },
-    "CScore": {
-      "props": {
-        "CUser": [
-          "User"
-        ],
-        "Boolean": [
-          "IsRegisteredForLadderMatch"
-        ],
-        "Real": [
-          "LadderScore",
-          "LadderMatchScoreValue"
-        ],
-        "Integer": [
-          "LadderRankSortValue",
-          "LadderClan"
         ]
       }
     },

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -1,10221 +1,13044 @@
 {
-  "primitives": [
-    "Void",
-    "Integer",
-    "Real",
-    "Boolean",
-    "Text",
-    "Vec2",
-    "Vec3",
-    "Int3",
-    "Ident"
-  ],
-  "classes": {
-    "CAchievementsAchievement": {
-      "props": {
-        "Ident": [
-          "UserId"
-        ],
-        "CAchievementsAchievementDesc": [
-          "AchievementDesc"
-        ]
-      }
-    },
-    "CAchievementsAchievementDesc": {
-      "props": {
-        "Text": [
-          "TitleId",
-          "DisplayName",
-          "Description",
-          "IconUrl"
-        ]
-      }
-    },
-    "CAchievementsEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CAchievementsAchievement": [
-          "Achievement"
-        ]
-      }
-    },
-    "CAchievementsManager": {
-      "props": {
-        "CAchievementsEvent[]": [
-          "PendingEvents"
-        ],
-        "CAchievementsAchievement[]": [
-          "Achievements"
-        ],
-        "CAchievementsStat[]": [
-          "Stats"
-        ],
-        "CAchievementsAchievementDesc[]": [
-          "AchivementsDescriptions"
-        ],
-        "CAchievementsStatDesc[]": [
-          "StatDescriptions"
-        ]
-      },
-      "methods":{
-        "SendEvent":{
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument" : "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Mnemo"
-            },
-            {
-              "identifier": "Integer[]",
-              "argument": "Params"
-            }
-          ],
-          "returns" : "Void"
-        }
-      }
-    },
-    "CAchievementsStat":{
-      "props": {
-        "Ident":[
-          "UserId"
-        ],
-        "CAchievementsStatDesc":[
-          "StatDesc"
-        ],
-        "Integer":[
-          "Value"
-        ]
-      }
-    },
-    "CAchievementsStatDesc": {
-      "props": {
-        "Text":[
-          "TitleId",
-          "DisplayName",
-          "Description"
-        ]
-      }
-    },
-    "CAnchorData": {
-      "props": {
-        "Text": [
-          "DefaultTag",
-          "Tag"
-        ],
-        "Integer": [
-          "DefaultOrder",
-          "Order"
-        ],
-        "CBlock": [
-          "Block"
-        ],
-        "CItemAnchor": [
-          "Item"
-        ]
-      }
-    },
-    "CAnimManager": {
-      "methods": {
-        "Add": {
-          "params": [
-            {
-              "identifier": "CMlControl",
-              "argument": "Control"
-            },
-            {
-              "identifier": "Text",
-              "argument": "XmlTarget"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "StartTime"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Duration"
-            },
-            {
-              "identifier": "EAnimManagerEasing",
-              "argument": "EasingFunc"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AddChain": {
-          "params": [
-            {
-              "identifier": "CMlControl",
-              "argument": "Control"
-            },
-            {
-              "identifier": "Text",
-              "argument": "XmlTarget"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Duration"
-            },
-            {
-              "identifier": "EAnimManagerEasing",
-              "argument": "EasingFunc"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CAnyEditorPlugin": {
-      "props": {
-        "CManiaAppEvent[]": [
-          "PendingEvents"
-        ],
-        "CEditorModule": [
-          "ModuleEditor"
-        ],
-        "CEditorMesh": [
-          "MeshEditor"
-        ],
-        "CEditorEditor": [
-          "EditorEditor"
-        ],
-        "EInteractionStatus": [
-          "InteractionStatus"
-        ]
-      }
-    },
-    "CAudioManager": {
-      "props": {
-        "CAudioSource[]": [
-          "Sounds"
-        ],
-        "Boolean": [
-          "ForceEnableMusic"
-        ],
-        "Real": [
-          "LimitMusicVolumedB",
-          "LimitSceneSoundVolumedB",
-          "LimitUiSoundVolumedB"
-        ]
-      },
-      "methods": {
-        "CreateSound": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Real",
-              "argument": "VolumedB"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsMusic"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsLooping"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsSpatialized"
-            }
-          ],
-          "returns": "CAudioSource"
-        },
-        "DestroySound": {
-          "params": [
-            {
-              "identifier": "CAudioSource",
-              "argument": "Sound"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PlaySoundEvent": {
-          "params": [
-            {
-              "identifier": "ELibSound",
-              "argument": "Sound"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SoundVariant"
-            },
-            {
-              "identifier": "Real",
-              "argument": "VolumedB"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Delay"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ClearAllDelayedSoundsEvents": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CAudioSource": {
-      "props": {
-        "Boolean": [
-          "IsPlaying",
-          "DownloadInProgress"
-        ],
-        "Real": [
-          "Volume",
-          "FadeDuration",
-          "VolumedB",
-          "Pitch",
-          "PlayCursor",
-          "PlayLength"
-        ],
-        "Vec3": [
-          "RelativePosition",
-          "PanRadiusLfe"
-        ]
-      },
-      "methods": {
-        "Play": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Stop": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CAudioSourceMusic": {
-      "props": {
-        "Real[]": [
-          "Tracks_Volume",
-          "Tracks_VolumedB",
-          "Tracks_Length"
-        ],
-        "Text[]": [
-          "Tracks_Name"
-        ],
-        "Integer": [
-          "Tracks_Count",
-          "BeatsPerBar"
-        ],
-        "Real": [
-          "BeatsPerMinute",
-          "BeatDuration",
-          "LPF_CutoffRatio",
-          "LPF_Q",
-          "HPF_CutoffRatio",
-          "HPF_Q",
-          "FadeTracksDuration",
-          "FadeFiltersDuration"
-        ],
-        "EUpdateMode": [
-          "UpdateMode"
-        ],
-        "Boolean": [
-          "Dbg_ForceIntensity",
-          "Dbg_ForceSequential",
-          "Dbg_ForceRandom",
-          "UseNewImplem"
-        ]
-      }
-    },
-    "CBadge": {
-      "props": {
-        "Vec3": [
-          "PrimaryColor"
-        ],
-        "Text": [
-          "SkinName"
-        ],
-        "Text[]": [
-          "Layers"
-        ]
-      },
-      "methods": {
-        "StickerSlot_Get": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Slot"
-            }
-          ],
-          "returns": "Text"
-        },
-        "StickerSlot_Set": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Slot"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Sticker"
-            }
-          ],
-          "returns": "Void"
-        },
-        "StickerSlot_Clear": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CBadgeEditor": {
-      "props": {
-        "CBadge": [
-          "DisplayCurrentBadge"
-        ],
-        "Vec2": [
-          "DisplayPosN",
-          "DisplaySize"
-        ],
-        "Real": [
-          "DisplayFoV",
-          "CameraTransitionDuration",
-          "MeshRotation_MaxSpeed",
-          "MeshRotation_Acceleration"
-        ],
-        "Ident": [
-          "DisplayCurrentMeshId"
-        ],
-        "Ident[]": [
-          "MeshIds"
-        ],
-        "CBadge[]": [
-          "Badges"
-        ]
-      },
-      "methods": {
-        "Leave": {
-          "params": [],
-          "returns": "Void"
-        },
-        "MeshId_Next": {
-          "params": [],
-          "returns": "Void"
-        },
-        "MeshId_Previous": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BadgeCreate": {
-          "params": [],
-          "returns": "CBadge"
-        },
-        "BadgeDestroy": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeCopy": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Source"
-            },
-            {
-              "identifier": "CBadge",
-              "argument": "Destination"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeReadFromProfile": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeWriteToProfile": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CBadgeManager": {
-      "props": {
-        "CBadge[]": [
-          "Badges"
-        ]
-      },
-      "methods": {
-        "BadgeCreate": {
-          "params": [],
-          "returns": "CBadge"
-        },
-        "BadgeDestroy": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeCopy": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Source"
-            },
-            {
-              "identifier": "CBadge",
-              "argument": "Destination"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeReadFromProfile": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BadgeWriteToProfile": {
-          "params": [
-            {
-              "identifier": "CBadge",
-              "argument": "Badge"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ProfileIsReady": {
-          "param": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
-    "CBlock": {
-      "props": {
-        "Integer": [
-          "BlockScriptId"
-        ],
-        "Boolean": [
-          "CanHaveAnchor"
-        ],
-        "Int3": [
-          "Coord"
-        ],
-        "CardinalDirections": [
-          "Direction"
-        ],
-        "CBlockUnit[]": [
-          "BlockUnits"
-        ],
-        "CBlockModel": [
-          "BlockModel"
-        ]
-      },
-      "methods": {
-        "UseDefaultAnchor": {
-          "params": [],
-          "returns": "Void"
-        },
-        "UseCustomAnchor": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CBlockModel": {
-      "props": {
-        "Text": [
-          "Name"
-        ],
-        "Boolean": [
-          "IsRoad",
-          "IsTerrain",
-          "isPodium",
-          "NoRespawn"
-        ],
-        "EWayPointType": [
-          "WaypointType"
-        ],
-        "CBlockModelVariantGround": [
-          "VariantGround"
-        ],
-        "CBlockModelVariantAir": [
-          "VariantAir"
-        ]
-      }
-    },
-    "CBlockModelClip": {
-    },
-    "CBlockModelVariant": {
-      "props": {
-        "Text": [
-          "Name"
-        ],
-        "Boolean": [
-          "IsAllUnderground",
-          "IsPartUnderground"
-        ],
-        "Int3": [
-          "Size",
-          "OffsetBoundingBoxMin",
-          "OffsetBoundingBoxMax"
-        ],
-        "CBlockUnitModel[]": [
-          "BlockUnitModels"
-        ]
-      }
-    },
-    "CBlockUnit": {
-      "props": {
-        "Int3": [
-          "Offset"
-        ],
-        "CBlockUnitModel": [
-          "BlockUnitModel"
-        ],
-        "CBlock": [
-          "Block"
-        ]
-      }
-    },
-    "CBlockUnitModel": {
-      "props": {
-        "Int3": [
-          "Offset"
-        ],
-        "CBlockModelClip[]": [
-          "Clips"
-        ]
-      }
-    },
-    "CCampaign": {
-      "props": {
-        "Text": [
-          "CampaignId",
-          "ScoreContext"
-        ],
-        "CMapGroup[]": [
-          "MapGroups"
-        ],
-        "Boolean": [
-          "OfficialRecordEnabled"
-        ]
-      },
-      "methods": {
-        "GetMapGroupCount": {
-          "params": [],
-          "returns": "Integer"
-        },
-        "GetMapGroup": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Index"
-            }
-          ],
-          "return": "CMapGroup"
-        },
-        "GetNextMap": {
-          "params": [
-            {
-              "identifier": "CMapInfo",
-              "argument": "CurrentMapInfo"
-            }
-          ]
-        }
-      }
-    },
-    "CClient": {
-      "props": {
-        "CUser": [
-          "User"
-        ],
-        "CUIConfig": [
-          "UI"
-        ],
-        "Boolean": [
-          "IsConnectedToMasterServer",
-          "IsSpectator"
-        ],
-        "Text": [
-          "ClientVersion",
-          "ClientTitleVersion"
-        ],
-        "Integer": [
-          "IdleDuration"
-        ]
-      }
-    },
-    "CCollector": {
-      "props": {
-        "Text": [
-          "Name",
-          "PageName"
-        ],
-        "Integer": [
-          "InterfaceNumber"
-        ],
-        "CImage": [
-          "Icon"
-        ]
-      }
-    },
-    "CDataFileMgr": {
-      "props": {
-        "CTaskResult[]": [
-          "TaskResults"
-        ],
-        "CCampaign[]": [
-          "Campaigns"
-        ],
-        "CGhost[]": [
-          "Ghosts"
-        ]
-      },
-      "methods": {
-        "TaskResult_Release": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TaskId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Campaign_Get": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            }
-          ],
-          "returns": "CCampaign"
-        },
-        "Map_RefreshFromDisk": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Map_GetUserList": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "CTaskResult_MapList"
-        },
-        "Map_GetGameList": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_MapList"
-        },
-        "Map_GetFilteredGameList": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Scope"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_MapList"
-        },
-        "Ghost_Release": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "GhostId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ghost_Download": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "CTaskResult_Ghost"
-        },
-        "Replay_RefreshFromDisk": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_GetGameList": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_ReplayList"
-        },
-        "Replay_GetFilteredGameList": {
-          "params": [
-            {
-              "identifier" : "Integer",
-              "argument": "Scope"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_ReplayList"
-        },
-        "Replay_Load": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            }
-          ],
-          "returns": "CTaskResult_GhostList"
-        },
-        "Replay_Save": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "CMap",
-              "argument": "Map"
-            },
-            {
-              "identifier": "CGhost",
-              "argument": "Ghost"
-            }
-          ],
-          "returns": "CTaskResult"
-        },
-        "Media_GetGameList": {
-          "params": [
-            {
-              "identifier": "EMediaType",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_FileList"
-        },
-        "Media_GetFilteredGameList": {
-          "params": [
-            {
-              "identifier": "EMediaType",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Scope"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_FileList"
-        },
-        "GameMode_GetGameList": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Scope"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Flatten"
-            }
-          ],
-          "returns": "CTaskResult_GameModeList"
-        },
-        "Pack_DownloadOrUpdate": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DisplayName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "CTaskResult"
-        }
-      }
-    },
-    "CEditorEditor":{
-      "props": {
-        "Boolean": [
-          "Bindings_RequestInput_Done"
-        ],
-        "Text[]": [
-          "BindingContexts",
-          "RequestedContextBindings"
-        ],
-        "CEditorEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "Bindings_AddContext": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_AddBinding": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "BindingScriptId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "BindingDisplayName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_RemoveContext": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_RemoveBinding": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_RequestInput": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_SetBindingScriptId": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingScriptId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "NewBindingScriptId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_SetBindingDisplayName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingScriptId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "BindingDisplayName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_SetContextName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "NewContextName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_GetContextBindings": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Bindings_GetBindingsActionName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingName"
-            }
-          ],
-          "returns": "Text"
-        },
-        "Bindings_GetBindingsDisplayName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingName"
-            }
-          ],
-          "returns": "Text"
-        }
-      }
-    },
-    "CEditorEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ]
-      }
-    },
-    "CEditorMainPlugin": {
-      "props": {
-        "CEditorPluginHandle[]": [
-          "Plugins"
-        ]
-      },
-      "methods": {
-        "Help_Open": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Help_Close": {
-          "params": [],
-          "returns": "Void"
-        },
-        "GetPluginHandle": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            }
-          ],
-          "returns": "CEditorPluginHandle"
-        },
-        "SendPluginEvent": {
-          "params": [
-            {
-              "identifier": "CEditorPluginHandle",
-              "argument": "Handle"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Context_SetActive": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsActive"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Context_IsActive": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ContextName"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Binding_IsActive": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BindingName"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Plugin_SetClearance": {
-          "params": [
-            {
-              "identifier": "CEditorPluginHandle",
-              "argument": "Handle"
-            },
-            {
-              "identifier": "EMeshEditorAPI",
-              "argument": "API"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "IsAllowed"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CEditorMesh": {
-      "props": {
-        "Boolean": [
-          "GoToMaterialEditor",
-          "IsCreateMaterial",
-          "Tmp_UseParts",
-          "EditionBox_IsPlaneOriented",
-          "DisplayVertices",
-          "DisplayFaces",
-          "DisplayJoints",
-          "GripSnap_IsActive",
-          "Display_HideElemsByDistance_IsActive",
-          "IsExperimental"
-        ],
-        "Integer": [
-          "VertexCount",
-          "EdgeCount",
-          "FaceCount",
-          "RotationStep",
-          "MaterialsUpdateId",
-          "Material_Atlas_SelectedSubTexIndex",
-          "CreationElemsCount",
-          "Display_HideElemsByDistance_Distance",
-          "PrefabNamesUpdateId"
-        ],
-        "Real": [
-          "Scale",
-          "Step",
-          "Size",
-          "RotationValue",
-          "ScalingStep",
-          "ScalingRatio",
-          "Display_HideElemsByDistance_Opacity"
-        ],
-        "EEdgesDisplay": [
-          "DisplayEdges"
-        ],
-        "Ident[]": [
-          "MaterialIds"
-        ],
-        "Text[]": [
-          "MaterialNames",
-          "PrefabNames"
-        ],
-        "EInteraction": [
-          "CurrentInteraction"
-        ],
-        "Ident": [
-          "SelectionSet"
-        ],
-        "CEditorEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "EditionBox_SetScale": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "Scale"
-            }
-          ],
-          "returns": "Void"
-        },
-        "EditionBox_OrientPlane": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "EditedMesh_Clear": {
-          "params": [],
-          "returns": "Void"
-        },
-        "EditedMesh_Simplify": {
-          "params": [],
-          "returns": "Void"
-        },
-        "EditedMesh_Lod": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "FacesRatio"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UVUnwrap": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "ETexCoordLayer",
-              "argument": "ETexCoordLayer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Undo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Redo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SwitchPlane": {
-          "params": [],
-          "returns": "Void"
-        },
-        "GridSnap_SetActive": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsActive"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PickInfo_GetNormal": {
-          "params": [],
-          "returns": "Vec3"
-        },
-        "PickInfo_GetPosition": {
-          "params": [],
-          "returns": "Vec3"
-        },
-        "PickInfo_GetEdgeLength": {
-          "params": [],
-          "returns": "Real"
-        },
-        "PickInfo_GetNextVertexPosition": {
-          "params": [],
-          "returns": "Vec3"
-        },
-        "PickInfo_GetMaterial": {
-          "params": [],
-          "returns": "Ident"
-        },
-        "PickInfo_GetError": {
-          "params": [],
-          "returns": "Text"
-        },
-        "Part_SetAnchorPos": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Part_SetIsJoint": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsJoint"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Part_ClearAnchor": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Material_GetMaterialIdSelected": {
-          "params": [],
-          "returns": "Ident"
-        },
-        "Material_SetMaterailIdSelected": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialEditorId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Materail_GetSubTexIndexSelected": {
-          "params": [],
-          "returns": "Integer"
-        },
-        "Material_MaterialLibGetCount": {
-          "params": [],
-          "returns": "Integer"
-        },
-        "Material_SetDefault": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_GetDefault": {
-          "params": [],
-          "returns": "Ident"
-        },
-        "Material_GetBitmapBase": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            }
-          ],
-          "returns": "CImage"
-        },
-        "Material": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            }
-          ],
-          "returns": "CImage"
-        },
-        "Material_MatchesCriterion": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            },
-            {
-              "identifier": "EMaterialFilterCriterion",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Material_SetFilter": {
-          "params": [
-            {
-              "identifier": "EMaterialFilterCriterion",
-              "argument": "Criterion"
-            },
-            {
-              "identifier": "EFilterKind",
-              "argument": "FilterKind"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_GetFilter": {
-          "params": [
-            {
-              "identifier": "EMaterialFilterCriterion",
-              "argument": "Criterion"
-            }
-          ],
-          "returns": "EFilterKind"
-        },
-        "Material_ClearFilters": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Material_UVEditor_SetIsRotation": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsRotation"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_UVEditor_SetIsScale": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsScale"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_UVEditor_SetIsScale1D": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsScale"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_UVEditor_Open": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            },
-            {
-              "identifier": "CMlQuad",
-              "argument": "LocationQuad"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_UVEditor_Close": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Material_UVEditor_SetMode": {
-          "params": [
-            {
-              "identifier": "EUVEditorMode",
-              "argument": "Mode"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_UVEditor_GetMode": {
-          "params": [],
-          "returns": "EUVEditorMode"
-        },
-        "Material_UVEditor_SetProjectionType": {
-          "params": [
-            {
-              "identifier": "EUVEditorProjectionType",
-              "argument": "ProjectionType"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Material_IsGameMaterial": {
-          "params": [],
-          "returns": "Boolean"
-        },
-        "Material_UVEditor_Apply": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Material_PasteMaterial": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Abort": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_SetPreview": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetToPreview"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartCreation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "CreationSetHandle"
-            },
-            {
-              "identifier": "EElemType",
-              "argument": "ElemType"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SetToPickFromHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Creation_GetElems": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_CloseCreation": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_Creation_ClearParams": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_Creation_SetEdgesConstraint": {
-          "params": [
-            {
-              "identifier": "EEdgesConstraint",
-              "argument": "EdgesConstraint"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Creation_SetAutoMerge": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "AutoMerge"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPaste": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_StartBlocTransformation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TransformationSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartCurve2D": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BordersSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_CloseCurve2D": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "CanDoCurve2D"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPick": {
-          "params": [
-            {
-              "identifier": "EElemType",
-              "argument": "ElemType"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SetToPickFrom"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPickJoint": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_StartMerge": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "MergeSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartMirror": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Selection_ClearParams": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_Selection_SetUseParts": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "UseParts"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Selection_SetCanEnterLeaf": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "CanEnterLeaf"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartSelection": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SelectionSetHandle"
-            },
-            {
-              "identifier": "EElemType",
-              "argument": "ElemType"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SelectionSetToPickFrom"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_CloseSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Interaction_StartTranslation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TranslationSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPickTranslation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TranslationSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartRotation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "RotationSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPickRotation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "RotationSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Rotation_SetStep": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "RotationStep"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartPickScale": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ScalingSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_Scale_SetStep": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "ScalingStep"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Interaction_StartSplit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Display_HighlightSet": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Display_ClearHighlighting": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Display_AtlasSelectionsSet": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "DisplayAtlasSelection"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Display_AtlasSelectionGet": {
-          "params": [],
-          "returns": "Boolean"
-        },
-        "Display_HideElemsByDistance_Start": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Display_HideElemsByDistance_Stop": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Display_HideMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Display_ShowMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "MergeAllSuperposedElements": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Selection_Undo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Selection_Redo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetOfElements_Create": {
-          "params": [],
-          "returns": "Ident"
-        },
-        "SetOfElements_CopyFrom": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "DestinationSet"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SourceSet"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_Append": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "DestinationSet"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SourceSet"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_Destroy": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_Empty": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_SetAllElements": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_SetAllFaces": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_DeleteElements": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfELements_HasHorizontalFaces": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "SetOfElements_HasVerticalFaces": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "SetOfElements_GetElemsCount": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "SetOfElements_GetVerticesCount": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "SetOfElements_GetEdgesCount": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "SetOfElements_GetFacesCount": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "ExtendSelectedSet": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetBordersSet": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SetBordersHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetBordersVertexs": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SetVertexHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SelectionSet_SelectAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Curve2DPolygon": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "FourVertexSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SubTexIndex"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AtlasSelection_Create": {
-          "params": [],
-          "returns": "Ident"
-        },
-        "AtlasSelection_GetAtlasSelectionHandleFromSet": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AtlasSelection_GAddAtlasSelectionFromSet": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "FourPointsHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AtlasSelection_SubAtlasSelection": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AtlasSelection_TextureAtlasSelection": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SubTexIndex"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AtlasSelection_GetAtlasSelectionAfterSelection": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Preview_Clear": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BlocTransformation_Start": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "BlocTransformation_Translate": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Translation"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BlocTransformation_Twist": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "Angle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BlocTransformation_Bend": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Axis"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Radius"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Angle"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Direction"
-            }
-          ],
-          "returns": "Void"
-        },
-        "BlocTransformation_Abort": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BlocTransformation_Close": {
-          "params": [],
-          "returns": "Void"
-        },
-        "VoxelSpace_Init": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Size"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseColors"
-            }
-          ],
-          "returns": "Void"
-        },
-        "VoxelSpace_Destroy": {
-          "params": [],
-          "returns": "Void"
-        },
-        "VoxelSpace_Get": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Pos"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "VoxelSpace_Set": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Pos"
-            }
-          ],
-          "returns": "Void"
-        },
-        "VoxelSpace_SetVec3": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Pos"
-            }
-          ],
-          "returns": "Void"
-        },
-        "VoxelSpace_Unset": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Pos"
-            }
-          ],
-          "returns": "Void"
-        },
-        "VoxelSpace_GenerateMesh": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetOfElements_ProjectOnPlane": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_ProjectOnGround": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Height"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_SplitEdgeWithVertex": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_CoolapseEdgeWithVertex": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_Subdivide": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfElements_Subdivide_Interpolation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawCircle": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "InputSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawDisc": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "InputSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawIcosahedron": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "InputSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawIcosahedricSphere": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "InputSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawPoly": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "InputSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "VerticesCount"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawSpline": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ControlSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_Weld": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "VerticesSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfVertices_DrawBox": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ControlSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfEdges_Fill": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfEdges_Flip": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfEdges_BorderExpand": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfOneEdge_FaceLoopExpand": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfOneEdge_EdgeLoopExpand": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfOneFace_CutHole": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "FaceSetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "EdgesSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfFaces_Extrude": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfFaces_QuadsToTriangles": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ResultSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfFaces_ApplyMaterial": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "SetHandle"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "MaterialId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfFaces_PlanarExpand": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "FacesSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetOfFaces_ChangeOrientation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "FacesSetHandle"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Prefab_Export": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Prefab_Import": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "PrefabIndex"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Parts_MergeSelectedParts": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Parts_Group": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Parts_UngroupSelectedParts": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Cut": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Copy": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetBaseUndoState": {
-          "params": [],
-          "returns": "Void"
-        },
-        "AddUndoState": {
-          "params": [],
-          "returns": "Void"
-        },
-        "AutoSave": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CEditorModule": {
-      "props": {
-        "CModuleMenuModel": [
-          "EditedMenu"
-        ],
-        "CModuleMenuPageModel": [
-          "EditedMenuPage"
-        ],
-        "CeditorPluginModuleEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "NewModule": {
-          "params": [
-            {
-              "identifier": "EModuleType",
-              "argument": "ModuleType"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenModule": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Save": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SaveAs": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SaveCopyAs": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ForceExit": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CEditorPluginModuleEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ]
-      },
-      "methods": {
-        "Eat": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CGameMatchSettingsPlaylistItemScript": {
-      "props": {
-        "Text": [
-          "Name"
-        ],
-        "Boolean": [
-          "FileExists"
-        ]
-      }
-    },
-    "CGameModeInfo": {
-      "props": {
-        "Text": [
-          "Name",
-          "Path",
-          "Description",
-          "Version"
-        ],
-        "Text[]": [
-          "CompatibleMapTypes"
-        ]
-      }
-    },
-    "CGamePlayerMapRecordScript": {
-      "props": {
-        "Text": [
-          "Context",
-          "MapUid",
-          "MapName",
-          "FileName",
-          "ReplayUrl"
-        ],
-        "Integer": [
-          "Score",
-          "Time",
-          "RespawnCount",
-          "Timestamp",
-          "MultiAsyncLevel",
-          "SkillPoints"
-        ]
-      }
-    },
-    "CGhost": {
-      "props": {
-        "Ident": [
-          "Id"
-        ],
-        "CTmResult": [
-          "Result"
-        ],
-        "Text": [
-          "Nickname"
-        ]
-      }
-    },
-    "CHighScoreComparison": {
-      "props": {
-        "CMapInfo": [
-          "MapInfo"
-        ],
-        "Text": [
-          "Login",
-          "RecordDateString",
-          "OpponentLogin",
-          "OpponentDisplayName",
-          "OpponentRecordUrl",
-          "OpponentRecordDateString"
-        ],
-        "Integer": [
-          "RecordScore",
-          "RecordTime",
-          "RecordRespawnCount",
-          "RecordDate",
-          "RecordElapsedTime",
-          "RecordCount",
-          "OpponentRecordScore",
-          "OpponentRecordTime",
-          "OpponentRecordResawnCount",
-          "OpponentRecordDate",
-          "OpponentRecordElapsedTime",
-          "OpponentRecordCount"
-        ]
-      }
-    },
-    "CHighScoreComparisonSummary": {
-      "props": {
-        "Text": [
-          "Login",
-          "BestRecordLastDateString",
-          "OpponentLogin",
-          "OpponentDisplayName",
-          "OppenentBestRecordLasDateString"
-        ],
-        "Integer": [
-          "BestRecordCount",
-          "BestRecordLastDate",
-          "BestRecordElapsedTime",
-          "OpponentBestRecordCount",
-          "OpponentBestRecordLastDate",
-          "OpponentBestRecordElapsedTime"
-        ]
-      }
-    },
-    "CHttpManager": {
-      "props": {
-        "CHttpRequest[]": [
-          "Requests"
-        ],
-        "Integer": [
-          "SlotsAvailable"
-        ],
-        "Boolean": [
-          "AutomaticHeaders_Timezone"
-        ]
-      },
-      "methods": {
-        "CreateGet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseCache"
-            }
-          ],
-          "returns": "CHttpRequest"
-        },
-        "CreatePost": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Resource"
-            }
-          ],
-          "returns": "CHttpRequest"
-        },
-        "Destroy": {
-          "params": [
-            {
-              "identifier": "CHttpRequest",
-              "argument": "Request"
-            }
-          ],
-          "returns": "Void"
-        },
-        "IsValidUrl": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
-    "CHttpRequest": {
-      "props": {
-        "Text": [
-          "Url",
-          "Result"
-        ],
-        "Integer": [
-          "StatusCode"
-        ],
-        "Boolean": [
-          "IsCompleted"
-        ]
-      }
-    },
-    "CInputEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CInputPad": [
-          "Pad"
-        ],
-        "EButton": [
-          "Button"
-        ],
-        "Boolean": [
-          "IsAutoRepeat"
-        ],
-        "Integer": [
-          "KeyCode"
-        ],
-        "Text": [
-          "KeyName"
-        ]
-      }
-    },
-    "CInputManager": {
-      "props": {
-        "CInputEvent[]": [
-          "PendingEvents"
-        ],
-        "Integer": [
-          "Now",
-          "Period",
-          "Dbg_AutoRepeat_I,itialDelay",
-          "Dbg_AutoRepea_Period"
-        ],
-        "CInputPad[]": [
-          "Pads"
-        ],
-        "Vec2": [
-          "MousePos"
-        ],
-        "Boolean": [
-          "MouseLeftButton",
-          "MouseRightButton",
-          "MouseMiddleButton",
-          "ExclusiveMode"
-        ]
-      },
-      "methods": {
-        "GetPadButtonPlaygroundBinding": {
-          "params": [
-            {
-              "identifier": "CInputPad",
-              "argument": "Pad"
-            },
-            {
-              "identifier": "EButton",
-              "argument": "Button"
-            }
-          ],
-          "returns": "Text"
-        },
-        "GetPadButtonCurrentBinding": {
-          "params": [
-            {
-              "identifier": "CInputPad",
-              "argument": "Pad"
-            },
-            {
-              "identifier": "EButton",
-              "argument": "Button"
-            }
-          ],
-          "returns": "Text"
-        },
-        "GetPadButtonBinding": {
-          "params": [
-            {
-              "identifier": "CInputPad",
-              "argument": "Pad"
-            },
-            {
-              "identifier": "EButton",
-              "argument": "Button"
-            }
-          ],
-          "returns": "Text"
-        },
-        "IsKeyPressed": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "KeyCode"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
-    "CInputPad": {
-      "props": {
-        "Integer": [
-          "ControllerId",
-          "IdleDuration",
-          "Left",
-          "Right",
-          "Up",
-          "Down",
-          "A",
-          "B",
-          "X",
-          "Y",
-          "L1",
-          "R1",
-          "LeftStickBut",
-          "RightStickBut",
-          "Menu",
-          "View"
-        ],
-        "Ident": [
-          "UserId"
-        ],
-        "EPadType": [
-          "Type"
-        ],
-        "Text": [
-          "ModelName"
-        ],
-        "Real": [
-          "LeftStickX",
-          "LeftStickY",
-          "RightStickX",
-          "RightStickY",
-          "L2",
-          "R2"
-        ],
-        "EButton[]": [
-          "ButtonEvents"
-        ]
-      },
-      "methods": {
-        "ClearRumble": {
-          "params": [],
-          "returns": "Void"
-        },
-        "AddRumble": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Duration"
-            },
-            {
-              "identifier": "Real",
-              "argument": "LargeMotor"
-            },
-            {
-              "identifier": "Real",
-              "argument": "SmallMotor"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetColor": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Color"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CItemAnchor": {
-      "props": {
-        "Vec3": [
-          "Position"
-        ]
-      }
-    },
-    "CMacroblockModel": {
-      "props": {
-        "Boolean": [
-          "IsGround",
-          "HasStart",
-          "HasFinish",
-          "HasCheckpoint"
-        ],
-        "CBlockModel": [
-          "GeneratedBlockModel"
-        ],
-        "Text": [
-          "Name"
-        ]
-      }
-    },
-    "CManiaApp": {
-      "props": {
-        "Text": [
-          "ManiaAppUrl",
-          "ManiaAppBaseUrl",
-          "CurrentLocalDateText",
-          "CurrentTimezone"
-        ],
-        "Integer": [
-          "Now",
-          "CurrentDate",
-          "LayersDefaultManialinkVersion"
-        ],
-        "Boolean": [
-          "IsVisible",
-          "EnableMenuNavigationInputs"
-        ],
-        "CUser": [
-          "LocalUser"
-        ],
-        "CTitle": [
-          "LoadedTitle"
-        ],
-        "ESystemPlatform": [
-          "SystemPlatform"
-        ],
-        "ESystemSkuIdentifier": [
-          "SystemSkuIdentifier"
-        ],
-        "CUILayer[]": [
-          "UILayers"
-        ],
-        "CXmlManager": [
-          "Xml"
-        ],
-        "CHttpManager": [
-          "Http"
-        ],
-        "CVideoManager": [
-          "Video"
-        ],
-        "CAudioManager": [
-          "Audio"
-        ],
-        "CInputManager": [
-          "Input"
-        ],
-        "CDataFileMgr": [
-          "DataFileMgr"
-        ],
-        "CScoreMgr": [
-          "ScoreMgr"
-        ],
-        "CPrivilegeMgr": [
-          "PrivilegeMgr"
-        ],
-        "CPresenceMgr": [
-          "PresenceMgr"
-        ],
-        "CUserV2Manager": [
-          "UserMgr"
-        ]
-      },
-      "methods": {
-        "UILayerCreate": {
-          "params": [],
-          "returns": "CUILayer"
-        },
-        "UILayerDestroy": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UILayerDestroyAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "LayerCustomEvent": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenLink": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "ELinkType",
-              "argument": "LinkType"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenFileExplorer": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Dialog_Message": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Message"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Dbg_DumpDeclareForVariables": {
-          "params": [
-            {
-              "identifier": "CNod",
-              "argument": "Nod"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "StatsOnly"
-            }
-          ],
-          "returns": "Text"
-        }
-      }
-    },
-    "CManiaAppBase": {
-      "props": {
-        "CManiaAppEvent[]": [
-          "PendingEvents"
-        ]
-      }
-    },
-    "CManiaAppBrowser": {
-      "props": {
-        "CManiaAppEvent[]": [
-          "PendingEvents"
-        ],
-        "Text": [
-          "BrowserFocusedFrameId"
-        ]
-      },
-      "methods": {
-        "BrowserBack": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserQuit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserHome": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserReload": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CManiaAppEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CUILayer": [
-          "CustomEventLayer"
-        ],
-        "Text": [
-          "CustomEventType",
-          "ExternalEventType",
-          "KeyName"
-        ],
-        "Text[]": [
-          "CustomEventData",
-          "ExternalEventData"
-        ],
-        "EMenuNavAction": [
-          "MenuNavAction"
-        ],
-        "Boolean": [
-          "IsActionAutoRepeat"
-        ],
-        "Integer": [
-          "KeyCode"
-        ]
-      }
-    },
-    "CManiaAppPlaygroundCommon": {
-      "props": {
-        "CManiaAppPlaygroundEvent[]": [
-          "PendingEvents"
-        ],
-        "CPlaygroundClient": [
-          "Playground"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "CUIConfig": [
-          "UI",
-          "ClientUI"
-        ]
-      }
-    },
-    "CManiaAppPlaygroundEvent": {
-      "props": {
-        "Text": [
-          "PlaygroundScriptEventType"
-        ],
-        "Text[]": [
-          "PlaygroundScriptEventData"
-        ]
-      }
-    },
-    "CManiaAppStation": {
-      "props": {
-        "CStation": [
-          "Station"
-        ],
-        "CPackCreatorTitleInfo[]": [
-          "Maker_EditedTitles"
-        ]
-      },
-      "methods": {
-        "EnterStation": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Maker_EditTitle": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "EditedTitleId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Maker_EditNewTitle": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "EditedTitleName"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CManiaAppTitle": {
-      "props": {
-        "CManiaAppEvent[]": [
-          "PendingEvents"
-        ],
-        "Boolean": [
-          "LoadingScreenRequireKeyPressed",
-          "DontScaleMainMenuForHMD",
-          "Authentication_GetTokenResponseReceived"
-        ],
-        "CTitleFlow": [
-          "TitleFlow",
-          "TitleControl"
-        ],
-        "CTitleEdition": [
-          "TitleEdition"
-        ],
-        "CNotificationsConsumer": [
-          "Notifications"
-        ],
-        "Text": [
-          "ExternalRequest_Type",
-          "Authentication_Token"
-        ],
-        "Text[]": [
-          "ExternalRequest_Data"
-        ],
-        "CAchievementsManager": [
-          "AchievementsManager"
-        ],
-        "CBadgeManager": [
-          "BadgeManager"
-        ],
-        "CMatchSettingsManager": [
-          "MatchSettingsManager"
-        ],
-        "Integer": [
-          "Authentication_ErrorCode"
-        ]
-      },
-      "methods": {
-        "Menu_Quit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Home": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Solo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Local": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Internet": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Editor": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Profile": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PlayMap": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Map"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ExternalRequest_Clear": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Authentication_GetToken": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "AppLogin"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CManiaAppTitleLayer": {
-      "props": {
-        "CManiaAppTitle": [
-          "ParentApp"
-        ],
-        "CTitleFlow": [
-          "TitleControl",
-          "TitleFlow"
-        ]
-      }
-    },
-    "CMap": {
-      "props": {
-        "CMapInfo": [
-          "MapInfo"
-        ],
-        "Text": [
-          "MapName",
-          "Comments",
-          "AuthorZoneIconUrl",
-          "CollectionName",
-          "DecorationName",
-          "AuthorLogin",
-          "AuthorNickName",
-          "AuthorZonePath",
-          "MapType",
-          "MapStyle",
-          "ObjectiveTextAuthor",
-          "ObjectiveTextGold",
-          "ObjectiveTextSilver",
-          "ObjectiveTextBronze"
-        ],
-        "Integer": [
-          "TMObjective_AuthorTime",
-          "TMObjective_GoldTime",
-          "TMObjective_SilverTime",
-          "TMObjective_BronzeTime",
-          "TMObjective_NbLaps",
-          "CopperPrice"
-        ],
-        "Boolean": [
-          "TMObjective_IsLapRace"
-        ],
-        "Int3": [
-          "Size"
-        ]
-      }
-    },
-    "CMapEditorPlugin": {
-      "props": {
-        "CMapEditorPluginEvent[]": [
-          "PendingEvents"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "Text": [
-          "MapName",
-          "ManialinkText"
-        ],
-        "PlaceMode": [
-          "PlaceMode"
-        ],
-        "EditMode": [
-          "EditMode"
-        ],
-        "Boolean": [
-          "IsEditorReadyForRequest",
-          "HoldLoadingScreen",
-          "IsUltraShadowsQualityAvailable",
-          "UndergroundMode",
-          "BlockStockMode",
-          "EnableAirMapping",
-          "EnableMixMapping",
-          "EnableEditorInputsCustomProcessing",
-          "EnableCursorShowingWhenInterfaceIsFocused",
-          "HideEditorInterface",
-          "HideBlockHelpers",
-          "ShowPlacementGrid",
-          "EditorInputIsDown_Menu",
-          "EditorInputIsDown_SwitchToRace",
-          "EditorInputIsDown_Undo",
-          "EditorInputIsDown_Redo",
-          "EditorInputIsDown_CursorUp",
-          "EditorInputIsDown_CursorRight",
-          "EditorInputIsDown_CursorDown",
-          "EditorInputIsDown_CursorLeft",
-          "EditorInputIsDown_CursorRaise",
-          "EditorInputIsDown_CursorLower",
-          "EditorInputIsDown_CursorTurn",
-          "EditorInputIsDown_CursorPick",
-          "EditorInputIsDown_CursorPlace",
-          "EditorInputIsDown_CursorDelete",
-          "EditorInputIsDown_CameraUp",
-          "EditorInputIsDown_CameraRight",
-          "EditorInputIsDown_CameraDown",
-          "EditorInputIsDown_CameraLeft",
-          "EditorInputIsDown_CameraZoomNext",
-          "EditorInputIsDown_Camera0",
-          "EditorInputIsDown_Camera1",
-          "EditorInputIsDown_Camera3",
-          "EditorInputIsDown_Camera7",
-          "EditorInputIsDown_Camera9",
-          "EditorInputIsDown_PivotChange",
-          "EditorInputIsDown_CursorTurnSlightly",
-          "EditorInputIsDown_CursorTurnSlightlyAntiClockwise",
-          "EditorInputIsDown_IconUp",
-          "EditorInputIsDown_IconRight",
-          "EditorInputIsDown_IconDown",
-          "EditorInputIsDown_IconLeft",
-          "EditorInputIsDown_RemoveAll",
-          "EditorInputIsDown_Save",
-          "EditorInputIsDown_SaveAs",
-          "EditorInputIsDown_MapStyle",
-          "EditorInputIsDown_ClassicMapEditor"
-        ],
-        "ShadowsQuality": [
-          "CurrentShadowsQuality"
-        ],
-        "Int3": [
-          "CursorCoord"
-        ],
-        "CardinalDirections": [
-          "CursorDir"
-        ],
-        "CBlockModel": [
-          "CursorBlockModel",
-          "CursorTerrainBlockModel"
-        ],
-        "CMacroblockModel": [
-          "CursorMacroblockModel"
-        ],
-        "Real": [
-          "CameraVAngle",
-          "CameraHAngle",
-          "CameraToTargetDistance",
-          "ThumbnailCameraVAngle",
-          "ThumbnailCameraHAngle",
-          "ThumbnailCameraRoll",
-          "ThumbnailCameraFovY",
-          "CursorBrightnessFactor",
-          "CollectionSquareSize",
-          "CollectionSquareHeight"
-        ],
-        "Vec3": [
-          "CameraTargetPosition",
-          "CameraPosition",
-          "ThumbnailCameraPosition",
-          "CustomSelectionRGB"
-        ],
-        "CItemAnchor[]": [
-          "Items"
-        ],
-        "Text[]": [
-          "MediatrackIngameClips",
-          "MediatrackIngameIsScriptClips"
-        ],
-        "Integer": [
-          "MediatrackIngameEditedClipIndex",
-          "CollectionGroundY"
-        ],
-        "CBlock[]": [
-          "Blocks"
-        ],
-        "CBlockModel[]": [
-          "BlockModels",
-          "TerrainBlockModels"
-        ],
-        "CMacroblockModel[]": [
-          "MacroblockModels"
-        ],
-        "CAnchorData[]": [
-          "AnchorData"
-        ],
-        "Int3[]": [
-          "CustomSelectionCoords"
-        ],
-        "ValidationStatus": [
-          "ValidationStatus"
-        ],
-        "CMlPage": [
-          "ManialinkPage"
-        ]
-      },
-      "methods": {
-        "ComputeShadows": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DisplayDefaultSetObjectivesDialog": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Undo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Redo": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Help": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Validate": {
-          "params": [],
-          "returns": "Void"
-        },
-        "AutoSave": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Quit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "QuickQuit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "QuitAndSetResult": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "QuickQuitAndSetResult": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "TestMapFromStart": {
-          "params": [],
-          "returns": "Void"
-        },
-        "TestMapFromCoord": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Void"
-        },
-        "TestMapWithMode": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "RulesModeName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SaveMap": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Path"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetRaceCamera": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Yaw"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Pitch"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Roll"
-            },
-            {
-              "identifier": "Real",
-              "argument": "FovY"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveAllBlocks": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllTerrain": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllOffZone": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllObjects": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RemoveAllBlocksAndTerrain": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ShowCustomSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "HideCustomSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Copy": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Cut": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_Remove": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_SelectAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyPaste_ResetSelection": {
-          "params": [],
-          "returns": "Void"
-        },
-        "OpenToolsMenu": {
-          "params": [],
-          "returns": "Void"
-        },
-        "EditMediatrackIngame": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PreloadAllBlocks": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PreloadAllItems": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CanPlaceBlock": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "OnGround"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "VariantIndex"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceBlock": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceBlock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "OnGround"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "VariantIndex"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceBlock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceRoadBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceRoadBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceTerrainBlocks_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceMacroblock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceMacroblock_NoDestruction": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CanPlaceMacroblock_NoTerrain": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "PlaceMacroblock_NoTerrain": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveMacroblock_NoTerrain": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetBlock": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            }
-          ],
-          "returns": "CBlock"
-        },
-        "IsBlockModelSkinnable": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetNbBlockModelSkins": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetBlockModelSkin": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SkinIndex"
-            }
-          ],
-          "returns": "Text"
-        },
-        "GetSkinDisplayName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "SkinFileName"
-            }
-          ],
-          "returns": "Text"
-        },
-        "GetBlockSkin": {
-          "params": [
-            {
-              "identifier": "CBlock",
-              "argument": "Block"
-            }
-          ],
-          "returns": "Text"
-        },
-        "SetBlockSkin": {
-          "params": [
-            {
-              "identifier": "CBlock",
-              "argument": "Block"
-            },
-            {
-              "identifier": "Text",
-              "argument": "SkinFileName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenBlockSkinDialog": {
-          "params": [
-            {
-              "identifier": "CBlock",
-              "argument": "Block"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveBlock": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "Coord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveTerrainBlocks": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetBlockGroundHeight": {
-          "params": [
-            {
-              "identifier": "CBlockModel",
-              "argument": "BlockModel"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "CoordX"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "CoordZ"
-            },
-            {
-              "identifier": "CardinalDirections",
-              "argument": "Dir"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetGroundHeight": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "CoordX"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "CoordZ"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetMouseCoordOnGround": {
-          "params": [],
-          "returns": "Int3"
-        },
-        "GetMouseCoordAtHeight": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "CoordY"
-            }
-          ],
-          "returns": "Int3"
-        },
-        "GetStartLineBlock": {
-          "params": [],
-          "returns": "CBlock"
-        },
-        "RemoveItem": {
-          "params": [
-            {
-              "identifier": "CAnchorData",
-              "argument": "Item"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "CopyPaste_AddOrSubSelection": {
-          "params": [
-            {
-              "identifier": "Int3",
-              "argument": "StartCoord"
-            },
-            {
-              "identifier": "Int3",
-              "argument": "EndCoord"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CopyPaste_Symmetrize": {
-          "params": [],
-          "returns": "Boolean"
-        },
-        "SaveMacroblock": {
-          "params": [
-            {
-              "identifier": "CMacroblockModel",
-              "argument": "MacroblockModel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetMacroblockModelFromFilePath": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MacroblockModelFilePath"
-            }
-          ],
-          "returns": "CMacroblockModel"
-        },
-        "GetTerrainBlockModelFromName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "TerrainBlockModelName"
-            }
-          ],
-          "returns": "CBlockModel"
-        },
-        "GetBlockModelFromName": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "BlockModelName"
-            }
-          ],
-          "returns": "CBlockModel"
-        },
-        "GetMapStyle": {
-          "params": [],
-          "returns": "Text"
-        },
-        "SetMapStyle": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MapStyle"
-            }
-          ],
-          "returns": "Text"
-        }
-      }
-    },
-    "CMapEditorPluginEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ],
-        "EInput": [
-          "Input"
-        ],
-        "Ident": [
-          "EditedAnchorDataId"
-        ],
-        "Boolean": [
-          "IsFromPad",
-          "IsFromMouse",
-          "IsFromKeyboard",
-          "OnlyScriptMetadataModified"
-        ]
-      }
-    },
-    "CMapEditorPluginLayer": {
-      "props": {
-        "CMapEditorPlugin": [
-          "Editor"
-        ]
-      }
-    },
-    "CMapGroup": {
-      "props": {
-        "CMapInfo[]": [
-          "MapInfos"
-        ]
-      },
-      "methods": {
-        "IsUnlocked": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMapInfo": {
-      "props": {
-        "Text": [
-          "MapUid",
-          "Comments",
-          "CollectionName",
-          "AuthorLogin",
-          "AuthorNickName",
-          "AuthorZonePath",
-          "AuthorZoneFlagUrl",
-          "AuthorCountryFlagUrl",
-          "MapType",
-          "MapStyle",
-          "Name",
-          "Path",
-          "FileName"
-        ],
-        "Integer": [
-          "CopperPrice",
-          "TMObjective_AuthorTime",
-          "TMObjective_GoldTime",
-          "TMObjective_SilverTime",
-          "TMObjective_BronzeTime"
-        ],
-        "Boolean": [
-          "Unlocked",
-          "IsPlayable",
-          "CreatedWithSimpleEditor",
-          "TMObjective_IsLapRace"
-        ]
-      }
-    },
-    "CMapType": {
-      "props": {
-        "Boolean": [
-          "CustomEditAnchorData",
-          "ValidationEndRequested",
-          "ValidationEndNoConfirm",
-          "IsSwitchedToPlayground"
-        ],
-        "ValidationStatus": [
-          "ValidationStatus"
-        ],
-        "Text": [
-          "ValidabilityRequirementsMessage"
-        ],
-        "CUIConfigMgr": [
-          "UIManager"
-        ],
-        "CUser[]": [
-          "Users"
-        ]
-      },
-      "methods": {
-        "ClearMapMetadata": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestEnterPlayground": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestLeavePlayground": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMatchSettings": {
-      "props": {
-        "Text": [
-          "Name",
-          "FileName",
-          "ScriptModeName"
-        ],
-        "CGameMatchSettingsPlaylistItemScript[]": [
-          "Playlist"
-        ]
-      },
-      "methods": {
-        "Playlist_FileExists": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "File"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Playlist_FileMatchesMode": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "File"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Playlist_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "File"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Playlist_Remove": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Index"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Playlist_SwapUd": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Index"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Playlist_SwapDown": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Index"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMatchSettingsManager": {
-      "props": {
-        "Boolean": [
-          "MatchSettings_EditScriptSettings_Ongoing"
-        ],
-        "CMatchSettings[]": [
-          "MatchSettings"
-        ]
-      },
-      "methods": {
-        "MatchSettings_Refresh": {
-          "params": [],
-          "returns": "Void"
-        },
-        "MatchSettings_Create": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FilePath"
-            }
-          ],
-          "returns": "CMatchSettings"
-        },
-        "MatchSettings_Save": {
-          "params": [
-            {
-              "identifier": "CMatchSettings",
-              "argument": "MatchSettings"
-            }
-          ],
-          "returns": "Void"
-        },
-        "MatchSettings_SaveAs": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FilePath"
-            },
-            {
-              "identifier": "CMatchSettings",
-              "argument": "MatchSettings"
-            }
-          ],
-          "returns": "CMatchSettings"
-        },
-        "MatchSettings_EditScriptSettings": {
-          "params": [
-            {
-              "identifier": "CMatchSettings",
-              "argument": "MatchSettings"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlBrowser": {
-      "props": {
-        "CManiaAppBrowser": [
-          "ParentApp"
-        ],
-        "CMap": [
-          "CurMap"
-        ],
-        "EBuddyResult": [
-          "BuddyDoResult"
-        ],
-        "Text": [
-          "BuddyDoErrorMessage",
-          "BrowserFocusedFrameId"
-        ],
-        "Boolean": [
-          "IsInBrowser"
-        ]
-      },
-      "methods": {
-        "ShowCurMapCard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserBack": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserQuit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserHome": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserReload": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetLocalUserClubLink": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ClubLink"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlControl": {
-      "props": {
-        "CMlFrame": [
-          "Parent"
-        ],
-        "Text": [
-          "ControlId",
-          "ToolTip"
-        ],
-        "Text[]": [
-          "ControlClasses"
-        ],
-        "Vec2": [
-          "Size",
-          "RelativePosition_V3",
-          "AbsolutePosition_V3"
-        ],
-        "AlignHorizontal": [
-          "HorizontalAlign"
-        ],
-        "AlignVertical": [
-          "VerticalAlign"
-        ],
-        "Boolean": [
-          "Visible",
-          "IsFocused"
-        ],
-        "Real": [
-          "ZIndex",
-          "RelativeScale",
-          "RelativeRotation",
-          "AbsoluteScale",
-          "AbsoluteRotation"
-        ]
-      },
-      "methods": {
-        "HasClass": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Class"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "DataAttributeExists": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "DataAttributeGet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            }
-          ],
-          "returns": "Text"
-        },
-        "DataAttributeSet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "DataValue"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Show": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Hide": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Unload": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Focus": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlEntry": {
-      "props": {
-        "Text": [
-          "Value"
-        ],
-        "ETextFormat": [
-          "TextFormat"
-        ],
-        "Real": [
-          "Opacity",
-          "TextSizeReal"
-        ],
-        "Vec3": [
-          "TextColor"
-        ],
-        "Integer": [
-          "MaxLine"
-        ],
-        "Boolean": [
-          "AutoNewLine"
-        ]
-      },
-      "methods": {
-        "StartEdition": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "NewText"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "SendSubmitEvent"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlFileEntry": {
-      "props": {
-        "Text": [
-          "FullFileName"
-        ]
-      }
-    },
-    "CMlFrame": {
-      "props": {
-        "CMlControl[]": [
-          "Controls"
-        ],
-        "Boolean": [
-          "ClipWindowActive",
-          "DisablePreload"
-        ],
-        "Vec2": [
-          "ClipWindowRelativePosition",
-          "ClipWindowSize"
-        ]
-      },
-      "methods": {
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ControlId"
-            }
-          ],
-          "returns": "CMlControl"
-        }
-      }
-    },
-    "CMlGauge": {
-      "props": {
-        "Text": [
-          "Style"
-        ],
-        "Real": [
-          "Ratio",
-          "GradingRatio"
-        ],
-        "Integer": [
-          "Clan"
-        ],
-        "Vec3": [
-          "Color"
-        ],
-        "Boolean": [
-          "DrawBackground",
-          "DrawBlockBackground",
-          "CenteredBar"
-        ]
-      },
-      "methods": {
-        "SetRatio": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "NewRatio"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetClan": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "NewClan"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlGraph": {
-      "props": {
-        "Vec2": [
-          "CoordsMin",
-          "CoordsMax"
-        ],
-        "CMlGraphCurve[]": [
-          "Curves"
-        ]
-      },
-      "methods": {
-        "AddCurve": {
-          "params": [],
-          "returns": "CMlGraphCurve"
-        },
-        "RemoveCurve": {
-          "params": [
-            {
-              "identifier": "CMlGraphCurve",
-              "argument": "Curve"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlGraphCurve": {
-      "props": {
-        "Vec2[]": [
-          "Points"
-        ],
-        "Vec3": [
-          "Color"
-        ],
-        "Text": [
-          "Style"
-        ],
-        "Real": [
-          "Width"
-        ]
-      },
-      "methods": {
-        "SortPoints": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlLabel": {
-      "props": {
-        "Text": [
-          "Style",
-          "Substyle",
-          "TextFont",
-          "Value"
-        ],
-        "Integer": [
-          "ValueLineCount",
-          "MaxLine"
-        ],
-        "Boolean": [
-          "AppendEllipsis",
-          "AutoNewLine"
-        ],
-        "Real": [
-          "LineSpacing",
-          "Opacity",
-          "TextSizeReal"
-        ],
-        "Vec3": [
-          "TextColor"
-        ],
-        "EBlendMode": [
-          "Blend"
-        ]
-      },
-      "methods": {
-        "SetText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "NewText"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ComputeWidth": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            }
-          ],
-          "returns": "Real"
-        },
-        "ComputeHeight": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            }
-          ],
-          "returns": "Real"
-        }
-      }
-    },
-    "CMlMediaPlayer": {
-      "props": {
-        "Boolean": [
-          "IsInitPlay",
-          "Music",
-          "IsLooping"
-        ],
-        "Real": [
-          "Volume"
-        ],
-        "Text": [
-          "Url"
-        ]
-      },
-      "methods": {
-        "Play": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Stop": {
-          "params": [],
-          "returns": "Void"
-        },
-        "StopAndRewind": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlMinimap": {
-      "props": {
-        "Vec3": [
-          "WorldPosition"
-        ],
-        "Vec2": [
-          "MapPosition"
-        ],
-        "Real": [
-          "MapYaw",
-          "ZoomFactor"
-        ],
-        "Boolean": [
-          "Underground"
-        ]
-      },
-      "methods": {
-        "Fog_SetAll": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "Value"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Fog_ClearDisk": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "WorldCenter"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Radius"
-            },
-            {
-              "identifier": "Real",
-              "argument": "FadeSize"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlPage": {
-      "props": {
-        "CMlFrame": [
-          "MainFrame"
-        ],
-        "Boolean": [
-          "LinksInhibited"
-        ],
-        "CMlControl[]": [
-          "GetClassChildren_Result"
-        ]
-      },
-      "methods": {
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ControlId"
-            }
-          ],
-          "returns": "CMlControl"
-        },
-        "GetClassChildren": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Class"
-            },
-            {
-              "identifier": "CMlFrame",
-              "argument": "Frame"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Recursive"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlQuad": {
-      "props": {
-        "CImage": [
-          "Image"
-        ],
-        "Text": [
-          "ImageUrl",
-          "ImageUrlFocus",
-          "Style",
-          "Substyle"
-        ],
-        "Boolean": [
-          "StyleSelected",
-          "DownloadInProgress"
-        ],
-        "Vec3": [
-          "Colorize",
-          "ModulateColor",
-          "BgColor",
-          "BgColorFocus"
-        ],
-        "Real": [
-          "Opacity"
-        ],
-        "EKeepRatioMode": [
-          "KeepRatio"
-        ],
-        "EBlendMode": [
-          "Blend"
-        ]
-      },
-      "methods": {
-        "ChangeImageUrl": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "fieldName"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlScript": {
-      "props": {
-        "CMlPage": [
-          "Page"
-        ],
-        "Boolean": [
-          "PageIsVisible",
-          "Dbg_WarnOnDroppedEvents",
-          "MouseLeftButton",
-          "MouseRightButton",
-          "MouseMiddleButton",
-          "KeyUp",
-          "KeyDown",
-          "KeyLeft",
-          "KeyRight",
-          "KeyReturn",
-          "KeySpace",
-          "KeyDelete",
-          "EnableMenuNavigationInputs",
-          "IsMenuNavigationForeground"
-        ],
-        "Integer": [
-          "Now",
-          "Period",
-          "CurrentTime"
-        ],
-        "Text": [
-          "CurrentTimeText",
-          "CurrentLocalDateText",
-          "CurrentTimezone"
-        ],
-        "CUser": [
-          "LocalUser"
-        ],
-        "CTitle": [
-          "LoadedTitle"
-        ],
-        "ESystemPlatform": [
-          "SystemPlatform"
-        ],
-        "ESystemSkuIdentifier": [
-          "SystemSkuIdentifier"
-        ],
-        "CMlScriptEvent[]": [
-          "PendingEvents"
-        ],
-        "Real": [
-          "MouseX",
-          "MouseY"
-        ],
-        "CXmlManager": [
-          "Xml"
-        ],
-        "CHttpManager": [
-          "Http"
-        ],
-        "CVideoManager": [
-          "Video"
-        ],
-        "CAudioManager": [
-          "Audio"
-        ],
-        "CInputManager": [
-          "Input"
-        ],
-        "CDataFileMgr": [
-          "DataFileMgr"
-        ],
-        "CScoreMgr": [
-          "ScoreMgr"
-        ],
-        "CPrivilegeMgr": [
-          "PrivilegeMgr"
-        ],
-        "CPresenceMgr": [
-          "PresenceMgr"
-        ],
-        "CAnimManager": [
-          "AnimManager"
-        ]
-      },
-      "methods": {
-        "Dbg_SetProcessed": {
-          "params": [
-            {
-              "identifier": "CMlScriptEvent",
-              "argument": "Event"
-            }
-          ],
-          "returns": "Void"
-        },
-        "IsKeyPressed": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "KeyCode"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "EnableMenuNavigation": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "EnableInputs"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "WithAutoFocus"
-            },
-            {
-              "identifier": "CMlControl",
-              "argument": "AutoBackControl"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "InputPriority"
-            }
-          ],
-          "returns": "Void"
-        },
-        "OpenLink": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "LinkType",
-              "argument": "LinkType"
-            }
-          ],
-          "returns": "Void"
-        },
-        "TriggerPageAction": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ActionString"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SendCustomEvent": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PreloadImage": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ImageUrl"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PreloadAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Dbg_DumpDeclareForVariables": {
-          "params": [
-            {
-              "identifier": "CNod",
-              "argument": "Nod"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "StatsOnly"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlScriptEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ],
-        "Integer": [
-          "KeyCode"
-        ],
-        "Text": [
-          "KeyName",
-          "CharPressed",
-          "ControlId",
-          "CustomEventType"
-        ],
-        "CMlControl": [
-          "Control"
-        ],
-        "EMenuNavAction": [
-          "MenuNavAction"
-        ],
-        "Boolean": [
-          "IsActionAutoRepeat"
-        ],
-        "Text[]": [
-          "CustomEventData"
-        ]
-      }
-    },
-    "CMlScriptIngame": {
-      "props": {
-        "Integer": [
-          "GameTime"
-        ],
-        "CPlaygroundClient": [
-          "Playground"
-        ],
-        "CUIConfig": [
-          "UI",
-          "ClientUI"
-        ],
-        "Boolean": [
-          "IsSpectator",
-          "IsSpectatorClient",
-          "UseClans",
-          "UseForcedClans",
-          "IsInGameMenuDisplayed"
-        ],
-        "CManiaAppPlaygroundCommon": [
-          "ParentApp"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "CTeam[]": [
-          "Teams"
-        ],
-        "Text": [
-          "CurrentServerLogin",
-          "CurrentServerName",
-          "CurrentServerDesc",
-          "CurrentServerJoinLink",
-          "CurrentServerModeName"
-        ],
-        "CAchievementsManager": [
-          "AchievementsManager"
-        ]
-      },
-      "methods": {
-        "ShowCurChallengeCard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ShowModeHelp": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyServerLinkToClipBoard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "JoinTeam1": {
-          "params": [],
-          "returns": "Void"
-        },
-        "JoinTeam2": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestSpectatorClient": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Spectator"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetSpectateTarget": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ShowProfile": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ShowInGameMenu": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CloseInGameMenu": {
-          "params": [
-            {
-              "identifier": "EInGameMenuResult",
-              "argument": "Result"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CloseScoresTable": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PlayUiSound": {
-          "params": [
-            {
-              "identifier": "EUISound",
-              "argument": "Sound"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SoundVariant"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Volume"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlStation": {
-      "props": {
-        "CManiaAppStation": [
-          "ParentApp"
-        ],
-        "CStation": [
-          "Station"
-        ]
-      },
-      "methods": {
-        "EnterStation": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlTextEdit": {
-      "props": {
-        "Text": [
-          "Value"
-        ],
-        "Integer": [
-          "MaxLine",
-          "ValueLineCount"
-        ],
-        "Boolean": [
-          "AutoNewLine",
-          "ShowLineNumbers"
-        ],
-        "Real": [
-          "LineSpacing",
-          "Opacity",
-          "TextSizeReal"
-        ],
-        "Vec3": [
-          "TextColor"
-        ],
-        "EControlScriptEditorTextFormat": [
-          "TextFormat"
-        ]
-      },
-      "methods": {
-        "StartEdition": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMode": {
-      "props": {
-        "Text": [
-          "ModeStatusMessage",
-          "ServerLogin",
-          "ServerName",
-          "ServerModeName",
-          "MapName",
-          "MapPlayerModelName",
-          "NeutralEmblemUrl",
-          "ForcedClubLinkUrl1",
-          "ForcedClubLinkUrl2",
-          "ClientManiaAppUrl"
-        ],
-        "CTitle": [
-          "LoadedTitle"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "CUser[]": [
-          "Users"
-        ],
-        "CTeam[]": [
-          "Teams"
-        ],
-        "Integer": [
-          "Now",
-          "Period",
-          "NextMapIndex"
-        ],
-        "Boolean": [
-          "MatchEndRequested",
-          "ServerShutdownRequested",
-          "MapLoaded",
-          "Ladder_RequestInProgress",
-          "Solo_NewRecordSequenceInProgress",
-          "UseMinimap",
-          "Replay_AutoStart"
-        ],
-        "CMapInfo[]": [
-          "MapList"
-        ],
-        "CUIConfigMgr": [
-          "UIManager"
-        ],
-        "CModulePlaygroundHud": [
-          "Hud"
-        ],
-        "CServerAdmin": [
-          "ServerAdmin"
-        ],
-        "CXmlRpc": [
-          "XmlRpc"
-        ],
-        "CXmlManager": [
-          "Xml"
-        ],
-        "CHttpManager": [
-          "Http"
-        ],
-        "CInputManager": [
-          "Input"
-        ],
-        "CDataFileMgr": [
-          "DataFileMgr"
-        ],
-        "CScoreMgr": [
-          "ScoreMgr"
-        ],
-        "ESystemPlatform": [
-          "SystemPlatform"
-        ],
-        "CAchievementsManager": [
-          "AchievementsManager"
-        ],
-        "CModeTurretManager": [
-          "TurretsManager"
-        ]
-      },
-      "methods": {
-        "TweakTeamColorsToAvoidHueOverlap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestLoadMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestUnloadMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Hud_Load": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModuleName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PassOn": {
-          "params": [
-            {
-              "identifier": "CUIConfigEvent",
-              "argument": "EventToPassOn"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Discard": {
-          "params": [
-            {
-              "identifier": "CUIConfigEvent",
-              "argument": "EventToDiscard"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_Request": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_AddPlayer": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_BeginRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_AddPlayer": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_EndRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_CloseMatchRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_CancelMatchRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_SetResultsVersion": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Version"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_SetMatchMakingMatchId": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "MatchId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_EnableChallengeMode": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Enable"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AutoTeamBalance": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Solo_SetNewRecord": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            },
-            {
-              "identifier": "EMedal",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Synchro_AddBarrier": {
-          "params": [],
-          "returns": "Integer"
-        },
-        "Synchro_BarrierReached": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Barrier"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Users_AreAllies": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User1"
-            },
-            {
-              "identifier": "CUser",
-              "argument": "User2"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Users_RequestSwitchToSpectator": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_CreateFake": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "NickName"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "RequestedTeam"
-            }
-          ],
-          "returns": "CUser"
-        },
-        "Users_DestroyFake": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_SetNbFakeUsers": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "NbTeam1"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "NbTeam2"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_DestroyAllFakes": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ItemList_Begin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ItemList_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ItemList_AddWithSkin": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "SkinName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ItemList_End": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_StartUsingToken": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_StopUsingToken": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_GetAndUseToken": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ActionList_Begin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ActionList_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ActionName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ActionList_End": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_Start": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_Stop": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Dbg_DumpDeclareForVariables": {
-          "params": [
-            {
-              "identifier": "CNod",
-              "argument": "Nod"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "StatsOnly"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModeTurret": {
-      "props": {
-        "Integer": [
-          "Armor",
-          "ArmorMax"
-        ],
-        "CModeTurret": [
-          "Owner"
-        ]
-      }
-    },
-    "CModeTurretManager": {
-      "props": {
-        "CModeTurret[]": [
-          "Turrets"
-        ]
-      },
-      "methods": {
-        "MapTurrets_Reset": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Turret_Create": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ModelId"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Direction"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Clan"
-            },
-            {
-              "identifier": "CPlayer",
-              "argument": "Owner"
-            }
-          ],
-          "returns": "CModeTurret"
-        },
-        "Turret_Destroy": {
-          "params": [
-            {
-              "identifier": "CModeTurret",
-              "argument": "Turret"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModuleMenu": {
-      "methods": {
-        "Menu_Goto": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "PageId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Menu_Back": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Previous": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Menu_Quit": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModuleMenuComponent": {
-      "props": {
-        "CUILayer": [
-          "ComponentLayer"
-        ]
-      },
-      "methods": {
-        "Hide": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Show": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModuleMenuFileBrowser": {
-      "props": {
-        "Boolean": [
-          "HesFinished"
-        ],
-        "Text[]": [
-          "Selection"
-        ]
-      },
-      "methods": {
-        "SetFileType": {
-          "params": [
-            {
-              "identifier": "EFileType",
-              "argument": "FileType"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetFileAction": {
-          "params": [
-            {
-              "identifier": "EFileAction",
-              "argument": "FileAction"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModuleMenuLayer": {
-      "props": {
-        "CModuleMenuComponent[]": [
-          "Components"
-        ]
-      },
-      "methods": {
-        "GetFirstComponent": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            }
-          ],
-          "returns": "CModuleMenuComponent"
-        }
-      }
-    },
-    "CModuleMenuModel": {
-      "props": {
-        "CModuleMenuPageModel[]": [
-          "Pages"
-        ],
-        "Text": [
-          "MenuScript"
-        ]
-      },
-      "methods": {
-        "AddPage": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "PageUrl"
-            }
-          ],
-          "returns": "CModuleMenuPageModel"
-        },
-        "AddLink": {
-          "params": [
-            {
-              "identifier": "CModuleMenuPageModel",
-              "argument": "ParentPage"
-            },
-            {
-              "identifier": "CModuleMenuPageModel",
-              "argument": "ChildPage"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModuleMenuPageModel": {
-      "props": {
-        "Text": [
-          "ManialinkText"
-        ]
-      }
-    },
-    "CModulePlayground": {
-      "methods": {
-        "Hide": {
-          "params": [
-            {
-              "identifier": "CUIConfig",
-              "argument": "UIConfig"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Show": {
-          "params": [
-            {
-              "identifier": "CUIConfig",
-              "argument": "UIConfig"
-            }
-          ],
-          "returns": "Void"
-        },
-        "IsVisble": {
-          "params": [
-            {
-              "identifier": "CUIConfig",
-              "argument": "UIConfig"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
-    "CModulePlaygroundHud": {
-      "props": {
-        "CModulePlaygroundInventory": [
-          "Inventory"
-        ],
-        "CModulePlaygroundStore": [
-          "Store"
-        ],
-        "CModulePlaygroundScoresTable": [
-          "ScoresTable"
-        ]
-      }
-    },
-    "CModulePlaygroundInventory": {
-      "methods": {
-        "AddItem": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Quantity"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "AddAction": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RemoveInventoryItem": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Quantity"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetInventoryItemQuantity": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "IsInventoryItemStored": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Url"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetStoredItemsList": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Tex[]"
-        },
-        "GetStoredActionsList": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Tex[]"
-        }
-      }
-    },
-    "CModulePlaygroundScoresTable": {
-      "methods": {
-        "SetFooterText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FooterText"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ResetCustomColumns": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "Score"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Scores_Sort": {
-          "params": [
-            {
-              "identifier": "EScoreSortOrder",
-              "argument": "SortOrder"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetColumnValue": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "Score"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ColumnId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ColumnValue"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetColumnVisibility": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ColumnId"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Visibility"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CModulePlaygroundStore": {
-      "methods": {
-        "Reset": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetMoney": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Amount"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetMoney": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "AddMoney": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Amount"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "SubMoney": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Amount"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "SetActionLevel": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ActionUrl"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ActionLevel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetActionLevel": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ActionUrl"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "SetItemCanBeBought": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ActionUrl"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "CanBeBought"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetItemCanBeBought": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ActionUrl"
-            }
-          ],
-          "returns": "Boolean"
-        }
-      }
-    },
-    "CNaturalLeaderBoardInfo": {
-      "props": {
-        "Integer": [
-          "Rank",
-          "Score"
-        ],
-        "Ident": [
-          "UserId"
-        ],
-        "Text": [
-          "Login",
-          "DisplayName",
-          "FileName",
-          "ReplayUrl"
-        ]
-      }
-    },
-    "CNod": {
-      "props": {
-        "Ident": [
-          "Id"
-        ]
-      }
-    },
-    "CNotificationsConsumer": {
-      "props": {
-        "CNotificationsConsumerEvent[]": [
-          "Events"
-        ],
-        "CNotificationsConsumerNotification[]": [
-          "Notifications",
-          "FilteredNotifications"
-        ],
-        "EFilterPriority": [
-          "Filter_Priority"
-        ]
-      }
-    },
-    "CNotificationsConsumerEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CNotificationsConsumerNotification": [
-          "Notification"
-        ]
-      }
-    },
-    "CNotificationsConsumerNotification": {
-      "props": {
-        "Text": [
-          "Title",
-          "Description",
-          "ImageUrl"
-        ],
-        "ENotificationPriority": [
-          "Priority"
-        ],
-        "Boolean": [
-          "HasBeenRead",
-          "HasBeenActivated"
-        ]
-      },
-      "methods": {
-        "SetRead": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetActivated": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "COnlinePresence": {
-      "props": {
-        "Text": [
-          "Login",
-          "DisplayName",
-          "ServerLogin"
-        ],
-        "Boolean": [
-          "IsOnline"
-        ]
-      }
-    },
-    "CPackCreator": {
-      "props": {
-        "Boolean": [
-          "RegisterPack_IsInProgess"
-        ],
-        "CPackCreatorPack": [
-          "CurrentPack"
-        ]
-      },
-      "methods": {
-        "RegisterPackForEditedTitle": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Build_Begin": {
-          "params": [
-            {
-              "identifier": "CPackCreatorPack",
-              "argument": "Pack"
-            },
-            {
-              "identifier": "CPackCreatorTitleInfo",
-              "argument": "TitleInfo"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Build_AddFile": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Build_AddFolder": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "FolderName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Build_Generate": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Upload"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Build_IsGenerated": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Build_ErrorMessage": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Build_End": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "BuildId"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CPackCreatorPack": {
-      "props": {
-        "Ident": [
-          "PackId",
-          "CreatorId"
-        ],
-        "Boolean": [
-          "IsTitlePack"
-        ],
-        "CPackCreatorRecipient[]": [
-          "Recipients"
-        ]
-      },
-      "methods": {
-        "Recipients_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "UseCost"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "GetCost"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Recipients_Remove": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CPackCreatorRecipient": {
-      "props": {
-        "Text": [
-          "Login"
-        ],
-        "Integer": [
-          "GetCost",
-          "UseCost"
-        ]
-      }
-    },
-    "CPackCreatorTitleInfo": {
-      "props": {
-        "Ident": [
-          "TitleId",
-          "MakerTitleId"
-        ],
-        "Text": [
-          "DisplayName",
-          "Description",
-          "InfoUrl",
-          "DownloadUrl",
-          "TitleVersion",
-          "AllowedClientTitleVersion",
-          "BaseTitleIds",
-          "ForcedPlayerModel",
-          "Packaging_ImageFileName",
-          "Packaging_LogosFileName",
-          "Packaging_Group",
-          "Station_ManialinkUrl",
-          "Menus_BgReplayFileName",
-          "Menus_ManiaAppFileName",
-          "Menus_MusicFileName",
-          "Hud3dFontFileName",
-          "MusicFolder"
-        ],
-        "Boolean": [
-          "Solo_HasCampaign"
-        ]
-      }
-    },
-    "CPlayer": {
-      "props": {
-        "CUser": [
-          "User"
-        ],
-        "Integer": [
-          "RequestedClan"
-        ],
-        "Boolean": [
-          "RequestsSpectate"
-        ]
-      }
-    },
-    "CPlaygroundClient": {
-      "props": {
-        "CMap": [
-          "Map"
-        ],
-        "Integer": [
-          "GameTime"
-        ],
-        "CUser": [
-          "LocalUser"
-        ],
-        "CUIConfig": [
-          "UI"
-        ],
-        "CServerInfo": [
-          "ServerInfo"
-        ],
-        "Boolean": [
-          "IsSpectator",
-          "IsSpectatorClient",
-          "UseClans",
-          "UseForcedClans",
-          "IsLoadingScreen",
-          "DisablePlayingStateTracking"
-        ],
-        "CTeam[]": [
-          "Teams"
-        ]
-      },
-      "methods": {
-        "QuitServer": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Silent"
-            }
-          ],
-          "returns": "Void"
-        },
-        "QuitServerAndSetResult": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Silent"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "JoinTeam1": {
-          "params": [],
-          "returns": "Void"
-        },
-        "JoinTeam2": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestSpectatorClient": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Spectator"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SepSpectateTarget": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ShowProfile": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CPresenceMgr": {
-      "props": {
-        "CTaskResult[]": [
-          "TaskResults"
-        ]
-      },
-      "methods": {
-        "ReleaseTaskResult": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TaskId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPresence": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "ERichPresence",
-              "argument": "UplayFlow"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetOnlinePresenceForPlayers": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "CTaskResult_GetOnlinePresence"
-        }
-      }
-    },
-    "CPrivilegeMgr": {
-      "props": {
-        "CTaskResult[]": [
-          "TaskResults"
-        ]
-      },
-      "methods": {
-        "ReleaseTaskResult": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TaskId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CheckPrivilege": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "EPrivilege",
-              "argument": "Privilege"
-            }
-          ],
-          "returns": "CTaskResult"
-        },
-        "CheckPrivilegeForAllUsers": {
-          "params": [
-            {
-              "identifier": "EPrivilege",
-              "argument": "Privilege"
-            }
-          ],
-          "returns": "CTaskResult"
-        },
-        "CheckTargetedPrivilege": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "EPrivilege",
-              "argument": "Privilege"
-            }
-          ],
-          "returns": "CTaskResult_CheckTargetedPrivilege"
-        },
-        "CheckTargetedPrivilegeForAllUsers": {
-          "params": [
-            {
-              "identifier": "EPrivilege",
-              "argument": "Privilege"
-            }
-          ],
-          "returns": "CTaskResult_CheckTargetedPrivilege"
-        }
-      }
-    },
-    "CRealLeaderBoardInfo": {
-      "props": {
-        "Integer": [
-          "Rank"
-        ],
-        "Ident": [
-          "UserId"
-        ],
-        "Text": [
-          "Login",
-          "DisplayName",
-          "FileName",
-          "ReplayUrl"
-        ],
-        "Real": [
-          "Score"
-        ]
-      }      
-    },
-    "CReplayInfo": {
-      "props": {
-        "Text": [
-          "MapUid",
-          "Name",
-          "Path",
-          "FileName"
-        ]
-      }
-    },
-    "CScore": {
-      "props": {
-        "CUser": [
-          "User"
-        ],
-        "Boolean": [
-          "IsRegisteredForLadderMatch"
-        ],
-        "Real": [
-          "LadderScore",
-          "LadderMatchScoreValue"
-        ],
-        "Integer": [
-          "LadderRankSortValue",
-          "LadderClan"
-        ]
-      }
-    },
-    "CScoreMgr": {
-      "props": {
-        "CTaskResult[]": [
-          "TaskResults"
-        ]
-      },
-      "methods": {
-        "TaskResult_Release": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "TaskId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScoreStatus_GetLocalStatus": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "ELocalScoreStatus"
-        },
-        "ScoreStatus_GetMasterServerStatus": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            }
-          ],
-          "returns": "EMasterServerScoreStatus"
-        },
-        "Playground_GetPlayerGhost": {
-          "params": [
-            {
-              "identifier": "CPlayer",
-              "argument": "GamePlayer"
-            }
-          ],
-          "returns": "CGhost"
-        },
-        "Map_SetNewRecord": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "CGhost",
-              "argument": "Ghost"
-            }
-          ],
-          "returns": "CTaskResult"
-        },
-        "Map_GetRecord": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Map_GetRecordGhost": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            }
-          ],
-          "returns": "CTaskResult_Ghost"
-        },
-        "Map_GetMultiAsyncLevel": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Map_GetMultiAsyncLevelRecord": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "MultiAsyncLevel"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Map_GetMultiAsyncLevelRecordGhost": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "MultiAsyncLevel"
-            }
-          ],
-          "returns": "CTaskResult_Ghost"
-        },
-        "Map_GetSkillPoints": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "MapLeaderBoard_GetPlayerRanking": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "MapLeaderBoard_GetPlayerCount": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "MapLeaderBoard_GetPlayerList": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Context"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "FromIndex"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Count"
-            }
-          ],
-          "returns": "CTaskResult_NaturalLeaderBoardInfoList"
-        },
-        "Campaign_GetMultiAsyncLevel": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Campaign_GetMultiAsyncLevelCount": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "MultiAsyncLevel"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Campaign_GetSkillPoints": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Campaign_GetOpponentRecords": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "OpponentLogin"
-            }
-          ],
-          "returns": "CWebServicesTaskResult_MapRecordListScript"
-        },
-        "Campaign_GetBuddiesMapRecord": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            }
-          ],
-          "returns": "CTaskResult_BuddiesChallengeRecord"
-        },
-        "Campaign_IsBuddiesMapRecordDirty": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapUid"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Campaign_GetBuddiesMapRecordsComparison": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            }
-          ],
-          "returns": "CTaskResult_BuddiesChallengeRecordsComparison"
-        },
-        "Campaign_GetBuddyMapRecordsComparison": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "OpponentLogin"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            }
-          ],
-          "returns": "CTaskResult_BuddyChallengeRecordsComparison"
-        },
-        "CampaignLeaderBoard_GetPlayerRanking": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseSkillPoints"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "CampaignLeaderBoard_GetPlayerCount": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseSkillPoints"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "CampaignLeaderBoard_GetPlayerList": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "CampaignId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "UseSkillPoints"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "FromIndex"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Count"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Multiplayer_AddToScore": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Real",
-              "argument": "ScoreDiff"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Timestamp"
-            }
-          ],
-          "returns": "Void"
-        },
-        "MultiplayerLeaderBoard_GetPlayerRanking": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "MultiplayerLeaderBoard_GetPlayerCount": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GlobalLeaderBoard_GetPlayerRanking": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GlobalLeaderBoard_GetPlayerCount": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GlobalLeaderBoard_GetPlayerList": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "UserId"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Zone"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "FromIndex"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Count"
-            }
-          ],
-          "returns": "CTaskResult_RealLeaderBoardInfoList"
-        }
-      }
-    },
-    "CServerAdmin": {
-      "props": {
-        "CServerInfo": [
-          "ServerInfo"
-        ]
-      },
-      "methods": {
-        "AutoTeamBalance": {
-          "params": [],
-          "returns": "Void"
-        },
-        "KickUser": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Reason"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "SetLobbyInfo": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsLobby"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "LobbyPlayerCount"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "LobbyMaxPlayerCount"
-            },
-            {
-              "identifier": "Real",
-              "argument": "LobbyPlayerLevel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SendToServerAfterMatch": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ServerUrl"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CustomizeQuitDialog": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ManialinkPage"
-            },
-            {
-              "identifier": "Text",
-              "argument": "SendToServerUrl"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "ProposeAddToFavorites"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ForceDelay"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CServerInfo": {
-      "props": {
-        "Text": [
-          "ServerName",
-          "ServerLogin",
-          "JoinLink",
-          "Comment",
-          "ServerVersionBuild",
-          "ServerLevelText",
-          "ModeName",
-          "SendToServerAfterMatchUrl"
-        ],
-        "Integer": [
-          "PlayerCount",
-          "MaxPlayerCount",
-          "SpectatorCount",
-          "MaxSpectatorCount",
-          "ServerLevel",
-          "NbChallenges"
-        ],
-        "Real": [
-          "PlayersLevelMin",
-          "PlayersLevelAvg",
-          "PlayersLevelMax",
-          "LadderServerLimitMax",
-          "LadderServerLimitMin"
-        ],
-        "Text[]": [
-          "PlayerNames",
-          "ChallengeNames"
-        ],
-        "Boolean": [
-          "HasBuddies",
-          "IsFavourite",
-          "IsLobbyServer",
-          "IsPrivate",
-          "IsPrivateForSpectator"
-        ]
-      }
-    },
-    "CSmAction": {
-      "props": {
-        "Integer": [
-          "Now",
-          "Variant",
-          "Energy",
-          "EnergyMax",
-          "EnergyCost",
-          "State_Integer1",
-          "Cooldown"
-        ],
-        "CSmPlayer[]": [
-          "Players"
-        ],
-        "CSmPlayer": [
-          "Owner"
-        ],
-        "Boolean": [
-          "IsActive",
-          "IsBound",
-          "EnergyReload",
-          "State_Boolean1",
-          "IsJumping",
-          "IsGliding",
-          "IsAttractor",
-          "IsFlying",
-          "IsSliding",
-          "IsRunning",
-          "IsFrozen",
-          "IsSneaking",
-          "IsFreeLooking",
-          "HasNoPlayerCollision"
-        ],
-        "Real": [
-          "AmmoGain"
-        ],
-        "Ident": [
-          "State_EntityId1"
-        ],
-        "CSmActionEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "SendRulesEvent": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Param1"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Param2"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Victim"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Anim_GetModelId": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Anim_PlayAtPosition": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "AnimModelId"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Direction"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Anim_PlayOnPlayer": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "AnimModelId"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Anim_Stop": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "AnimId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Projectile_GetModelId": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Projectile_CreateAtLocation": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ProjectileModelId"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "PlayerToIgnore"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialPosition"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialDirection"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialVelocity"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Projectile_CreateOnPlayer": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ProjectileModelId"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Cooldown_IsReady": {
-          "params": [],
-          "returns": "Boolean"
-        },
-        "Cooldown_Start": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Shield_CreateAtLocation": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Direction"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Shield_CreateOnPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "ShieldOwner"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "Shield_Destroy": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Shield_Exists": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Shield_GetArmor": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Shield_SetArmor": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ShieldArmor"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Shield_GetIsActive": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Shield_SetIsActive": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "SheildIsActive"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Shield_GetArmorMax": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Shield_GetTickReload": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "Shield_GetCooldown": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ShieldId"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetPlayerAmmo": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetPlayerAmmoMax": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Integer"
-        }
-      }
-    },
-    "CSmActionEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CSmPlayer": [
-          "Player"
-        ],
-        "CSmObject": [
-          "Object"
-        ],
-        "Integer": [
-          "Damage",
-          "ContextId",
-          "Shield"
-        ],
-        "Ident": [
-          "ProjectileModelId"
-        ],
-        "Vec3": [
-          "Position",
-          "Direction",
-          "Normal"
-        ]
-      }
-    },
-    "CSmBase": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "NumberOfCollectors"
-        ],
-        "Boolean": [
-          "IsActive"
-        ]
-      }
-    },
-    "CSmBlock": {
-      "props": {
-        "CSmBase": [
-          "Base"
-        ]
-      }
-    },
-    "CSmBlockPole": {
-      "props": {
-        "Boolean": [
-          "Captured"
-        ],
-        "CSmSector": [
-          "Sector"
-        ],
-        "CSmGauge": [
-          "Gauge"
-        ]
-      }
-    },
-    "CSmGauge": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "Value",
-          "Max",
-          "Speed"
-        ],
-        "Real": [
-          "ValueReal"
-        ]
-      }
-    },
-    "CSmLandmark": {
-      "props": {
-        "Text": [
-          "Tag"
-        ],
-        "Integer": [
-          "Order"
-        ],
-        "Vec3": [
-          "Position",
-          "DirFront"
-        ]
-      }
-    },
-    "CSmMapBase": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "NumberOfCollectors"
-        ],
-        "Boolean": [
-          "IsActive"
-        ]
-      }
-    },
-    "CSmMapBotPath": {
-      "props": {
-        "Integer": [
-          "Clan"
-        ],
-        "Vec3[]": [
-          "Path"
-        ],
-        "Boolean": [
-          "IsFlying"
-        ]
-      }
-    },
-    "CSmMapBotSpawn": {
-      "props": {
-        "Boolean": [
-          "IsFlying"
-        ],
-        "Ident": [
-          "BotModelId"
-        ]
-      }
-    },
-    "CSmMapGate": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "AutoCloseDelay",
-          "AutoOpenSpeed"
-        ],
-        "Boolean": [
-          "Automatic",
-          "ManualClosed",
-          "AutoClosed",
-          "AutoIsActive"
-        ]
-      }
-    },
-    "CSmMapGauge": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "Value",
-          "Max",
-          "Speed"
-        ],
-        "Real": [
-          "ValueReal"
-        ],
-        "Boolean": [
-          "Captured"
-        ]
-      }
-    },
-    "CSmMapLandmark": {
-      "props": {
-        "Text": [
-          "Tag"
-        ],
-        "Integer": [
-          "Order"
-        ],
-        "Vec3": [
-          "Position"
-        ],
-        "CSmMapBase": [
-          "Base"
-        ],
-        "CSmMapGate": [
-          "Gate"
-        ],
-        "CSmMapGauge": [
-          "Gauge"
-        ],
-        "CSmMapSector": [
-          "Sector"
-        ],
-        "CSmMapPlayerSpawn": [
-          "PlayerSpawn"
-        ],
-        "CSmMapBotPath": [
-          "BotPath"
-        ],
-        "CSmMapBotSpawn": [
-          "BotSpawn"
-        ],
-        "CSmMapObjectAnchor": [
-          "ObjectAnchor"
-        ]
-      }
-    },
-    "CSmMapObjectAnchor": {
-      "props": {
-        "Text": [
-          "ItemName"
-        ],
-        "Ident": [
-          "ItemModelId"
-        ]
-      }
-    },
-    "CSmMapPlayerSpawn": {
-      "props": {}
-    },
-    "CSmMapSector": {
-      "props": {
-        "Ident[]": [
-          "PlayersIds"
-        ],
-        "Text": [
-          "Tag"
-        ]
-      }
-    },
-    "CSmMapType": {
-      "props": {
-        "CSmMode": [
-          "Mode"
-        ],
-        "CSmPlayer[]": [
-          "AllPlayers",
-          "Players"
-        ]
-      }
-    },
-    "CSmMlScriptIngame": {
-      "props": {
-        "Integer": [
-          "ArenaNow"
-        ],
-        "CSmPlayer": [
-          "InputPlayer",
-          "GUIPlayer"
-        ],
-        "CSmPlayer[]": [
-          "Players"
-        ],
-        "CSmScore[]": [
-          "Scores"
-        ],
-        "Integer[]": [
-          "ClanScores"
-        ],
-        "Boolean": [
-          "HideResumePlayingButton"
-        ],
-        "CSmMapBase[]": [
-          "MapBases"
-        ],
-        "CSmMapLandmark[]": [
-          "MapLandmarks",
-          "MapLandmarks_PlayerSpawn",
-          "MapLandmarks_Gauge",
-          "MapLandmarks_Sector",
-          "MapLandmarks_BotPath",
-          "MapLandmarks_BotSpawn",
-          "MapLandmarks_ObjectAnchor",
-          "MapLandmarks_Gate"
-        ]
-      }
-    },
-    "CSmMode": {
-      "props": {
-        "Integer": [
-          "StartTime",
-          "EndTime",
-          "SpawnInvulnerabilityDuration",
-          "GameplayVersion",
-          "PlayersNbTotal",
-          "PlayersNbAlive",
-          "PlayersNbDead",
-          "ClansNbTotal",
-          "ClansNbAlive",
-          "ClansNbDead"
-        ],
-        "Boolean": [
-          "UseClans",
-          "UseForcedClans",
-          "UsePvPCollisions",
-          "UsePvPWeapons",
-          "UseInterractiveScreensIn3d",
-          "UseLaserVsBullets",
-          "UseLaserSkewering",
-          "UsePlayerTagging",
-          "UseBeaconsWithRecipients",
-          "UseAmmoBonusOnHit",
-          "UseSameWallJump",
-          "UseDefaultActionEvents",
-          "UseAllies",
-          "UseAutoSpawnBots",
-          "UseAutoRespawnBots",
-          "WalkOnWall",
-          "UseAutoDiscardBotEvents",
-          "ForceNavMapsComputation",
-          "UseProtectClanmates"
-        ],
-        "EGameplay": [
-          "Gameplay"
-        ],
-        "Real": [
-          "OffZoneRadius",
-          "OffZoneRadiusSpeed"
-        ],
-        "Ident": [
-          "OffZoneCenterLandmarkId"
-        ],
-        "Integer[]": [
-          "ClansNbPlayers",
-          "ClansNbPlayersAlive",
-          "ClanScores"
-        ],
-        "CSmPlayer[]": [
-          "Players",
-          "BotPlayers",
-          "Spectators",
-          "AllPlayers"
-        ],
-        "CSmModeEvent[]": [
-          "PendingEvents"
-        ],
-        "CSmMapBase[]": [
-          "MapBases"
-        ],
-        "CSmMapLandmark[]": [
-          "MapLandmarks",
-          "MapLandmarks_PlayerSpawn",
-          "MapLandmarks_Gauge",
-          "MapLandmarks_Sector",
-          "MapLandmarks_BotPath",
-          "MapLandmarks_BotSpawn",
-          "MapLandmarks_ObjectAnchor",
-          "MapLandmarks_Gate"
-        ],
-        "CSmScore[]": [
-          "Scores"
-        ],
-        "CSmObject[]": [
-          "Objects"
-        ]
-      },
-      "methods": {
-        "PassOn": {
-          "params": [
-            {
-              "identifier": "CSmModeEvent",
-              "argument": "Event"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Discard": {
-          "params": [
-            {
-              "identifier": "CSmModeEvent",
-              "argument": "Event"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SpawnPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ClanNum"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Armor"
-            },
-            {
-              "identifier": "CSmMapPlayerSpawn",
-              "argument": "PlayerSpawn"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ActivationDate"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SpawnBotPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ClanNum"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Armor"
-            },
-            {
-              "identifier": "CSmMapBotPath",
-              "argument": "BotPath"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ActivationDate"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UnspawnPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ClearScores": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetPlayerClan": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ClanNum"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayerWeapon": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "DefaultWeapon"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "AutoSwitchWeapon"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayerReloadAllWeapons": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "ReloadAllWeapons"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayerAmmo": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Count"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetPlayerAmmo": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "AddPlayerAmmo": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            },
-            {
-              "identifier": "Real",
-              "argument": "DeltaCount"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayerAmmoMax": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Count"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetPlayerAmmoMax": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "AddPlayerArmor": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Victim"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "DeltaArmor"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ShooterPoints"
-            }
-          ],
-          "returns": "Void"
-        },
-        "RemovePlayerArmor": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Victim"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "DeltaArmor"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ShooterPoints"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetWeaponNum": {
-          "params": [
-            {
-              "identifier": "EWeapon",
-              "argument": "Weapon"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "CanRespawnPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "RespawnPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "CSmMapLandmark",
-              "argument": "CheckpointLandmark"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CreateBotPlayer": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ModelId"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "TeamNum"
-            }
-          ],
-          "returns": "CSmPlayer"
-        },
-        "DestroyBotPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "DestroyAllBotPlayers": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ScriptedBot_Move": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Goal"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_MoveDelta": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Delta"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_MoveAndAim": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Goal"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_MoveDeltaAndAim": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Delta"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_Aim": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Goal"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_AimDelta": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            },
-            {
-              "identifier": "Real",
-              "argument": "DeltaYaw"
-            },
-            {
-              "identifier": "Real",
-              "argument": "DeltaPitch"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_RequestAction": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ScriptedBot_RequestGunTrigger": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "BotPlayer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ActionLoad": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EActionSlot",
-              "argument": "ActionSlot"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ModelId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ActionBind": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EActionSlot",
-              "argument": "ActionSlot"
-            },
-            {
-              "identifier": "EActionInput",
-              "argument": "ActionInput"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ActionSetVariant": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "EActionSlot",
-              "argument": "ActionSlot"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ActionVariant"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetNbFakePlayers": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "NbClan1"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "NbClan2"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ObjectCreate": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "ModelId"
-            }
-          ],
-          "returns": "CSmObject"
-        },
-        "ObjectDestroy": {
-          "params": [
-            {
-              "identifier": "CSmObject",
-              "argument": "Object"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ObjectDestroyAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_SaveAttackScore": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Score"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Replay_SaveDefenseScore": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Score"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Replay_SaveTeamScore": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Team"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "Score"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Replay_SavePlayerOfInterest": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Replay_SaveWinner": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Replay_SaveInterface": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CSmModeEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CSmPlayer": [
-          "Player",
-          "Shooter",
-          "Victim"
-        ],
-        "Integer": [
-          "Damage",
-          "VictimShield",
-          "ShooterPoints",
-          "ShooterClan",
-          "WeaponNum",
-          "ShooterWeaponNum",
-          "VictimWeaponNum",
-          "CommandValueInteger",
-          "ActionChange"
-        ],
-        "CSmObject": [
-          "VictimObject",
-          "Object"
-        ],
-        "CModeTurret": [
-          "VictimTurret",
-          "ShooterTurret"
-        ],
-        "Real": [
-          "Height",
-          "MissDist",
-          "CommandValueReal"
-        ],
-        "Boolean": [
-          "ShooterUsedAction",
-          "VictimUsedAction",
-          "PlayerWasSpawned",
-          "PlayerWasInLadderMatch",
-          "GiveUp",
-          "CommandValueBoolean"
-        ],
-        "EActionSlot": [
-          "ShooterActionSlot",
-          "VictimActionSlot",
-          "Action_Slot"
-        ],
-        "Text": [
-          "ShooterActionId",
-          "VictimActionId",
-          "ActionId",
-          "Param1",
-          "CommandName",
-          "CommandValueText"
-        ],
-        "EActionInput": [
-          "ActionInput"
-        ],
-        "Text[]": [
-          "Param2"
-        ],
-        "CSmMapSector": [
-          "Sector"
-        ],
-        "CSmBlockPole": [
-          "BlockPole"
-        ],
-        "CSmMapLandmark": [
-          "Landmark"
-        ],
-        "CUser": [
-          "User"
-        ],
-        "Vec3": [
-          "PlayerLastPosition",
-          "PlayerLastAimDirection"
-        ]
-      }
-    },
-    "CSmObject": {
-      "props": {
-        "EStatus": [
-          "Status"
-        ],
-        "Ident": [
-          "ModelId"
-        ],
-        "CSmPlayer": [
-          "Player"
-        ],
-        "CSmMapLandmark": [
-          "AnchorLandmark"
-        ],
-        "Vec3": [
-          "Position",
-          "Vel"
-        ],
-        "Integer": [
-          "MachineState"
-        ],
-        "Boolean": [
-          "Throwable"
-        ]
-      },
-      "methods": {
-        "SetAnchor": {
-          "params": [
-            {
-              "identifier": "CSmMapObjectAnchor",
-              "argument": "ObjectAnchor"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayer": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPosition": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPositionAndVel": {
-          "params": [
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Vel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetUnspawned": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CSmPlayer": {
-      "props": {
-        "CSmScore": [
-          "Score"
-        ],
-        "ESpawnStatus": [
-          "SpawnStatus"
-        ],
-        "Integer": [
-          "StartTime",
-          "EndTime",
-          "CurWeapon",
-          "CurAmmo",
-          "CurAmmoMax",
-          "CurAmmoUnit",
-          "Armor",
-          "ArmorMax",
-          "ArmorGain",
-          "ArmorReplenishGain",
-          "Stamina",
-          "CurrentClan",
-          "IdleDuration"
-        ],
-        "Real": [
-          "AmmoGain",
-          "AmmoPower",
-          "ArmorPower",
-          "StaminaMax",
-          "StaminaGain",
-          "StaminaPower",
-          "SpeedPower",
-          "JumpPower",
-          "EnergyLevel",
-          "GetLinearHue",
-          "ForceLinearHue",
-          "ThrowSpeed",
-          "AimYaw",
-          "AimPitch",
-          "Speed"
-        ],
-        "Boolean": [
-          "AutoSwitchWeapon",
-          "AllowWallJump",
-          "AllowProgressiveJump",
-          "UseAlternateWeaponVisual",
-          "IsHighlighted",
-          "HasShield",
-          "IsInVehicle",
-          "IsUnderground",
-          "IsTouchingGround",
-          "IsInAir",
-          "IsOnTechGround",
-          "IsOnTechLaser",
-          "IsOnTechArrow",
-          "IsOnTechArmor",
-          "IsOnTechSafeZone",
-          "IsOnTech",
-          "IsOnTechNoWeapon",
-          "IsInWater",
-          "IsInOffZone",
-          "IsCapturing",
-          "IsFakePlayer",
-          "IsBot"
-        ],
-        "Vec3": [
-          "ForceColor",
-          "Position",
-          "AimDirection",
-          "Velocity"
-        ],
-        "Ident": [
-          "ForceModelId"
-        ],
-        "CSmMapLandmark": [
-          "CapturedLandmark"
-        ],
-        "CSmObject[]": [
-          "Objects"
-        ],
-        "CSmPlayerDriver": [
-          "Driver"
-        ]
-      }
-    },
-    "CSmPlayerDriver": {
-      "props": {
-        "ESmDriverBehaviour": [
-          "Behaviour"
-        ],
-        "Real": [
-          "AggroRadius",
-          "ShootRadius",
-          "TargetMinDistance",
-          "DisengageDistance",
-          "PathSpeedCoef",
-          "Accuracy",
-          "Fov",
-          "Agressivity",
-          "Escape_DistanceSafe",
-          "Escape_DistanceMinEscape",
-          "Escape_DistanceMaxEscape",
-          "Saunter_Radius"
-        ],
-        "Integer": [
-          "ReactionTime",
-          "ShootPeriodMin",
-          "ShootPeriodMax",
-          "PathOffset",
-          "Saunter_BaseChillingTime",
-          "Saunter_ChillingTimeDelta"
-        ],
-        "Boolean": [
-          "RocketAnticipation",
-          "IsStuck",
-          "IsFlying",
-          "UseOldShootingSystem",
-          "Scripted_ForceAimInMoveDir"
-        ],
-        "ESmAttackFilter": [
-          "AttackFilter"
-        ],
-        "CSmPlayer": [
-          "Target",
-          "Owner",
-          "ForcedTarget"
-        ],
-        "ESmDriverPatrolMode": [
-          "Patrol_Mode"
-        ],
-        "Vec3": [
-          "Escape_AnchorPoint",
-          "Saunter_AnchorPoint"
-        ],
-        "CSmPlayer[]": [
-          "TargetsToAvoid"
-        ]
-      }
-    },
-    "CSmScore": {
-      "props": {
-        "Integer": [
-          "TeamNum",
-          "Points",
-          "RoundPoints",
-          "NbEliminationsInflicted",
-          "NbEliminationsTaken",
-          "NbRespawnsRequested",
-          "DamageInflicted",
-          "DamageTaken"
-        ]
-      },
-      "methods": {
-        "Clear": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CSmSector": {
-      "props": {
-        "Ident[]": [
-          "PlayersIds"
-        ]
-      }
-    },
-    "CStation": {
-      "props": {
-        "CTitle": [
-          "Title"
-        ],
-        "Integer": [
-          "AudienceRegisteredUsers",
-          "CampaignMedalsMax",
-          "CampaignMedalsCurrent",
-          "CampaignMedalsRanking",
-          "LadderRank",
-          "NextEchelonPercent"
-        ],
-        "Real": [
-          "LadderPoints",
-          "GhostAlpha"
-        ],
-        "EEchelon": [
-          "Echelon"
-        ],
-        "Boolean": [
-          "DisableQuickEnter",
-          "IsLogoVisible",
-          "IsEditable"
-        ],
-        "Vec3": [
-          "FocusLightColor",
-          "NormalLightColor"
-        ]
-      }
-    },
-    "CTaskResult": {
-      "props": {
-        "Ident": [
-          "Id"
-        ],
-        "Boolean": [
-          "IsProcessing",
-          "HasSucceeded",
-          "HasFailed",
-          "IsCanceled"
-        ],
-        "ETaskErrorType": [
-          "ErrorType"
-        ],
-        "Integer": [
-          "ErrorCode"
-        ],
-        "Text": [
-          "ErrorDescription"
-        ]
-      },
-      "methods": {
-        "Cancel": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTaskResult_BuddiesChallengeRecord": {
-      "props": {
-        "Text": [
-          "Login"
-        ],
-        "CHighScoreComparison[]": [
-          "BuddiesChallengeRecord"
-        ]
-      },
-      "methods": {
-        "SortByOpponentCount": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentDisplayName": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentLogin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentRecordDate": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentRecordTime": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTaskResult_BuddiesChallengeRecordsComparison": {
-      "props": {
-        "Text": [
-          "Login"
-        ],
-        "CHighScoreComparisonSummary[]": [
-          "BuddiesChallengeRecord"
-        ]
-      },
-      "methods": {
-        "SortByPlayerCount": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentLogin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentCount": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentDate": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByOpponentDisplayName": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTaskResult_BuddyChallengeRecordsComparison": {
-      "props": {
-        "Text": [
-          "Login",
-          "BuddyLogin"
-        ],
-        "CHighScoreComparison[]": [
-          "PlayerBestRecordsComparison",
-          "BuddyBestRecordsComparison"
-        ]
-      },
-      "methods": {
-        "SortByMapName": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByReccordTime": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByReccordTimeDiff": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SortByReccordDate": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTaskResult_CheckTargetedPrivilege": {
-      "methods": {
-        "AddLogin": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            }
-          ],
-          "returns": "Void"
-        },
-        "StartTask": {
-          "params": [],
-          "returns": "Void"
-        },
-        "HasPrivilege": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetDenyReason": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            }
-          ],
-          "returns": "Text"
-        }
-      }
-    },
-    "CTaskResult_FileList": {
-      "props": {
-        "Text": [
-          "ParentPath",
-          "Path"
-        ],
-        "Text[]": [
-          "Files",
-          "SubFolders"
-        ]
-      }
-    },
-    "CTaskResult_GameModeList": {
-      "props": {
-        "CGameModeInfo[]": [
-          "GamesModes"
-        ]
-      }
-    },
-    "CTaskResult_GetOnlinePresence": {
-      "props": {
-        "COnlinePresence[]": [
-          "OnlinePresences"
-        ]
-      },
-      "methods": {
-        "AddLogin": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Login"
-            }
-          ],
-          "returns": "Void"
-        },
-        "StartTask": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTaskResult_Ghost": {
-      "props": {
-        "CGhost": [
-          "Ghost"
-        ]
-      }
-    },
-    "CTaskResult_GhostList": {
-      "props": {
-        "CGhost[]": [
-          "Ghosts"
-        ]
-      }
-    },
-    "CTaskResult_MapList": {
-      "props": {
-        "Text": [
-          "ParentPath",
-          "Path"
-        ],
-        "CMapInfo[]": [
-          "MapInfos"
-        ],
-        "Text[]": [
-          "SubFolders"
-        ]
-      }
-    },
-    "CTaskResult_NaturalLeaderBoardInfoList": {
-      "props": {
-        "Integer": [
-          "FromIndex",
-          "Count"
-        ],
-        "CNaturalLeaderBoardInfo[]": [
-          "LeaderBoardInfo"
-        ]
-      }
-    },
-    "CTaskResult_RealLeaderBoardInfoList": {
-      "props": {
-        "Integer": [
-          "FromIndex",
-          "Count"
-        ],
-        "CRealLeaderBoardInfo[]": [
-          "LeaderBoardInfo"
-        ]
-      }
-    },
-    "CTaskResult_ReplayList": {
-      "props": {
-        "Text": [
-          "ParentPath",
-          "Path"
-        ],
-        "CReplayInfo[]": [
-          "ReplayInfos"
-        ],
-        "Text[]": [
-          "SubFolders"
-        ]
-      }
-    },
-    "CTaskResult_StringIntList": {
-      "props": {
-        "Text[]": [
-          "Values"
-        ]
-      }
-    },
-    "CTeam": {
-      "props": {
-        "Text": [
-          "Name",
-          "ZonePath",
-          "City",
-          "EmblemUrl",
-          "PresentationManialinkUrl",
-          "ClubLinkUrl",
-          "ColorText",
-          "ColorizedName"
-        ],
-        "Vec3": [
-          "ColorPrimary",
-          "ColorSecondary"
-        ]
-      }
-    },
-    "CTitle": {
-      "props": {
-        "Text": [
-          "TitleId",
-          "AuthorLogin",
-          "AuthorName",
-          "Name",
-          "Desc",
-          "InfoUrl",
-          "DownloadUrl",
-          "TitleVersion",
-          "MakerTitleId",
-          "BaseTitleId"
-        ]
-      }
-    },
-    "CTitleEdition": {
-      "props": {
-        "CTitle": [
-          "TitleMaker"
-        ],
-        "CPackCreator": [
-          "PackCreator"
-        ],
-        "Text": [
-          "EditedTitleId"
-        ],
-        "CPackCreatorTitleInfo": [
-          "EditedTitleInfo"
-        ],
-        "Boolean": [
-          "Dialog_IsFinished",
-          "Dialog_Success",
-          "Dialog_Aborted"
-        ]
-      },
-      "methods": {
-        "File_ImportFromUser": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "File_Move": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "OrigName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "DestNameOrFolder"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "KeepOriginalCopy"
-            }
-          ],
-          "returns": "Void"
-        },
-        "File_Exists": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            },
-            {
-              "identifier": "EDrive",
-              "argument": "InDrive"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "File_Delete": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "File_WriteText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            }
-          ],
-          "returns": "Void"
-        },
-        "File_ReadText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "FileName"
-            }
-          ],
-          "returns": "Text"
-        },
-        "Dialog_ImportFiles": {
-          "params": [],
-          "returns": "Void"
-        },
-        "OpenTitleFolderInExplorer": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ReloadTitleDesc": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SaveTitleDesc": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetTitleCampaign": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "CampaignNum"
-            },
-            {
-              "identifier": "Text",
-              "argument": "ScoreContext"
-            },
-            {
-              "identifier": "Text",
-              "argument": "MapsFolderNameOrPlayListName"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "OfficialRecordEnabled"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTmMlScriptIngame": {
-      "props": {
-        "CTmMlPlayer": [
-          "InputPlayer",
-          "GUIPlayer"
-        ],
-        "Integer": [
-          "NbLaps",
-          "MapNbLaps"
-        ],
-        "Boolean": [
-          "IndependantLaps",
-          "MapIsLapRace"
-        ],
-        "CTmMlPlayer[]": [
-          "Players"
-        ],
-        "CTmScore[]": [
-          "Scores"
-        ],
-        "Integer[]": [
-          "ClanScores"
-        ],
-        "Vec3": [
-          "MapStartLinePos"
-        ],
-        "Vec3[]": [
-          "MapCheckpointPos",
-          "MapFinishLinePos"
-        ]
-      }
-    },
-    "CTmMode": {
-      "props": {
-        "CTmPlayer[]": [
-          "AllPlayers",
-          "Spectators",
-          "Players",
-          "PlayersRacing",
-          "PlayersWaiting"
-        ],
-        "CTmScore[]": [
-          "Scores"
-        ],
-        "Integer": [
-          "Clan1Score",
-          "Clan2Score",
-          "ClansNbTotal",
-          "CutOffTimeLimit",
-          "NbLaps",
-          "UiScoresPointsLimit",
-          "ForceMaxOpponents",
-          "MapNbLaps"
-        ],
-        "Integer[]": [
-          "ClanScores",
-          "ClansNbPlayers"
-        ],
-        "CTmModeEvent[]": [
-          "PendingEvents"
-        ],
-        "Boolean": [
-          "IndependantLaps",
-          "UseClans",
-          "UseForcedClans",
-          "UiRounds",
-          "UiLaps",
-          "UiStuntsMode",
-          "UiDisplayStuntsNames",
-          "UiDisableHelpMessage",
-          "HideOpponents",
-          "EnableLegacyXmlRpcCallbacks",
-          "MedalGhost_ShowGold",
-          "MedalGhost_ShowSilver",
-          "MedalGhost_ShowBronze",
-          "MapIsLapRace"
-        ],
-        "ETMRespawnBehaviour": [
-          "RespawnBehaviour"
-        ],
-        "ETmRaceChronoBehaviour": [
-          "UiRaceChrono"
-        ],
-        "EPersonalGhost": [
-          "PersonalGhost"
-        ],
-        "Vec3": [
-          "MapStartLinePos"
-        ],
-        "Vec3[]": [
-          "MapCheckpointPos",
-          "MapFinishLinePos"
-        ]
-      },
-      "methods": {
-        "PassOn": {
-          "params": [
-            {
-              "identifier": "CTmModeEvent",
-              "argument": "Event"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Discard": {
-          "params": [
-            {
-              "identifier": "CTmModeEvent",
-              "argument": "Event"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SpawnPlayer": {
-          "params": [
-            {
-              "identifier": "CTmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ClanNum"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "RaceStartTime"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UnspawnPlayer": {
-          "params": [
-            {
-              "identifier": "CTmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetPlayerClan": {
-          "params": [
-            {
-              "identifier": "CTmPlayer",
-              "argument": "Player"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ClanNum"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Scores_Sort": {
-          "params": [
-            {
-              "identifier": "ETmScoreSortOrder",
-              "argument": "SortOrder"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Scores_Clear": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_ComputeRank": {
-          "params": [
-            {
-              "identifier": "ETmScoreSortOrder",
-              "argument": "SortOrder"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTmMapType": {
-      "props": {
-        "CTmMode": [
-          "Mode"
-        ],
-        "CTmPlayer[]": [
-          "AllPlayers",
-          "Players"
-        ]
-      }
-    },
-    "CUser": {
-      "props": {
-        "Text": [
-          "Login",
-          "Name",
-          "AvatarUrl",
-          "ZonePath",
-          "ZoneFlagUrl",
-          "CountryFlagUrl",
-          "Language",
-          "Description",
-          "ClubLink",
-          "BroadcastTVLogin",
-          "SteamUserId",
-          "LadderZoneName",
-          "LadderZoneFlagUrl"
-        ],
-        "Vec3": [
-          "Color"
-        ],
-        "Integer": [
-          "FameStars",
-          "LadderRank",
-          "LadderTotal",
-          "RequestedClan"
-        ],
-        "EEchelon": [
-          "Echelon"
-        ],
-        "Boolean": [
-          "IsBeginner",
-          "RequestsSpectate",
-          "IsFakeUser"
-        ],
-        "Real": [
-          "LadderPoints"
-        ],
-        "Integer[]": [
-          "Tags_Favored_Indices"
-        ],
-        "Text[]": [
-          "Tags_Id",
-          "Tags_Comments",
-          "Tags_Deliverer",
-          "AlliesConnected"
-        ],
-        "ETagType[]": [
-          "Tags_Type"
-        ],
-        "EStereoDisplayMode": [
-          "StereoDisplayMode"
-        ]
-      }
-    },
-    "CXmlManager": {
-      "props": {
-        "CXmlDocument[]": [
-          "Documents"
-        ]
-      },
-      "methods": {
-        "Create": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Contents"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "GenerateText"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "GenerateTextRaw"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "GenerateTextResursive"
-            }
-          ],
-          "returns": "CXmlDocument"
-        },
-        "Destroy": {
-          "params": [
-            {
-              "identifier": "CXmlDocument",
-              "argument": "Document"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CUILayer": {
-      "props": {
-        "Boolean": [
-          "IsVisible"
-        ],
-        "EUILayerType": [
-          "Type"
-        ],
-        "Text": [
-          "AttachId",
-          "ManialinkPage"
-        ],
-        "CMlPage": [
-          "LocalPage"
-        ]
-      }
-    },
-
-    "CTmMlPlayer": {
-      "props": {
-        "Integer": [
-          "CurrentClan",
-          "RaceStartTime",
-          "LapStartTime",
-          "CurrentNbLaps",
-          "CurTriggerIndex",
-          "CurCheckpointRaceTime",
-          "CurCheckpointLapTime",
-          "DisplaySpeed"
-        ],
-        "ERaceState": [
-          "RaceState"
-        ],
-        "Boolean": [
-          "IsSpawned"
-        ],
-        "CTrackManiaScore": [
-          "Score"
-        ],
-        "CTmResult": [
-          "CurRace",
-          "CurLap"
-        ],
-        "Real": [
-          "AccelCoef",
-          "ControlCoef",
-          "GravityCoef",
-          "AimYaw",
-          "AimPitch",
-          "Distance",
-          "Speed"
-        ],
-        "Vec3": [
-          "Position",
-          "AimDirection"
-        ]
-      }
-    },
-    "CTmScore": {
-      "props": {
-        "Integer": [
-          "TeamNum",
-          "Points",
-          "PrevRaceDeltaPoints"
-        ],
-        "CTmResult": [
-          "BestRace",
-          "BestLap",
-          "PrevRace",
-          "TempResult"
-        ]
-      },
-      "methods": {
-        "Clear": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTmPlayer": {
-      "props": {
-        "Integer": [
-          "CurrentClan",
-          "RaceStartTime",
-          "CurrentNbLaps",
-          "CurTriggerIndex"
-        ],
-        "CTmScore": [
-          "Score"
-        ],
-        "Boolean": [
-          "IsSpawned"
-        ],
-        "CTmResult": [
-          "CurRace",
-          "CurLap"
-        ],
-        "Vec3": [
-          "Position",
-          "AimDirection"
-        ],
-        "Real": [
-          "AimYaw",
-          "AimPitch",
-          "AccelCoef",
-          "ControlCoef",
-          "GravityCoef"
-        ]
-      }
-    },
-    "CTmModeEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CTmPlayer": [
-          "Player"
-        ],
-        "Integer": [
-          "RaceTime",
-          "CheckpointInRace",
-          "CheckpointInLap",
-          "LapTime",
-          "StuntsScore",
-          "NbRespawns",
-          "Angle",
-          "Points",
-          "Combo",
-          "CommandValueInteger"
-        ],
-        "Boolean": [
-          "IsEndLap",
-          "IsEndRace",
-          "IsStraight",
-          "IsReverse",
-          "IsMasterJump",
-          "PlayerWasSpawned",
-          "PlayerWasInLadderMatch",
-          "CommandValueBoolean"
-        ],
-        "Ident": [
-          "BlockId"
-        ],
-        "Real": [
-          "Speed",
-          "Distance",
-          "Damages",
-          "Factor",
-          "CommandValueReal"
-        ],
-        "EStuntFigure": [
-          "StuntFigure"
-        ],
-        "CUser": [
-          "User"
-        ],
-        "Text": [
-          "CommandName",
-          "CommandValueText"
-        ]
-      }
-    },
-    "CXmlDocument": {
-      "props": {
-        "Text": [
-          "TextContents"
-        ],
-        "CXmlNode": [
-          "Root"
-        ],
-        "CXmlNode[]": [
-          "Nodes"
-        ]
-      },
-      "methods": {
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            }
-          ],
-          "returns": "CXmlNode"
-        }
-      }
-    },
-    "CUIConfigMgr": {
-      "props": {
-        "CUIConfig": [
-          "UIAll"
-        ],
-        "CUIConfig[]": [
-          "UI"
-        ],
-        "CUILayer[]": [
-          "UILayers",
-          "UIReplayLayers"
-        ],
-        "Integer": [
-          "UISequenceMaxDuration"
-        ]
-      },
-      "methods": {
-        "ResetAll": {
-          "params": [],
-          "returns": "Void"
-        },
-        "GetUI": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "CUIConfig"
-        },
-        "UILayerCreate": {
-          "params": [],
-          "returns": "CUILayer"
-        },
-        "UILayerDestroy": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            }
-          ],
-          "returns": "Void"
-        },
-        "UILayerDestroyAll": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CXmlRpc": {
-      "props": {
-        "CXmlRpcEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "SendCallback": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Param1"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Param2"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SendCallbackArray": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Type"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Data"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SendCallback_BeginRound": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SendCallback_EndRound": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CUIConfig": {
-      "props": {
-        "EUISequence": [
-          "UISequence"
-        ],
-        "Boolean": [
-          "UISequenceIsCompleted",
-          "UISequence_CanSkipIntroMT",
-          "OverlayHideNotices",
-          "OverlayHideMapInfo",
-          "OverlayHideOpponentsInfo",
-          "OverlayHideChat",
-          "OverlayHideCheckPointList",
-          "OverlayHideRoundScores",
-          "OverlayHideCountdown",
-          "OverlayHideCrosshair",
-          "OverlayHideGauges",
-          "OverlayHideConsumables",
-          "OverlayHide321Go",
-          "OverlayHideBackground",
-          "OverlayHideChrono",
-          "OverlayHideSpeedAndDist",
-          "OverlayHidePersonnalBestAndRank",
-          "OverlayHidePosition",
-          "OverlayHideCheckPointTime",
-          "OverlayHideEndMapLadderRecap",
-          "OverlayHideMultilapInfos",
-          "OverlayHideSpectatorControllers",
-          "OverlayHideSpectatorInfos",
-          "OverlayChatHideAvatar",
-          "NoticesFilter_HidePlayerInfo",
-          "NoticesFilter_HidePlayerWarning",
-          "NoticesFilter_HidePlayerInfoIfNotMe",
-          "NoticesFilter_HidePlayerWarningIfNotMe",
-          "NoticesFilter_HideMapInfo",
-          "NoticesFilter_HideMapWarning",
-          "NoticesFilter_HideMatchInfo",
-          "NoticesFilter_HideMatchWarning",
-          "ScoreTableOnlyManialink",
-          "AltMenuNoDefaultScores",
-          "AltMenuNoCustomScores",
-          "OverlayScoreSummary",
-          "ScreenIn3dHideScoreSummary",
-          "ScreenIn3dHideVersus",
-          "ForceSpectator"
-        ],
-        "Text": [
-          "UISequence_CustomMTClip",
-          "UISequence_PodiumPlayersWin",
-          "UISequence_PodiumPlayersLose",
-          "ManialinkPage",
-          "BigMessage",
-          "BigMessageAvatarLogin",
-          "StatusMessage",
-          "GaugeMessage",
-          "MarkersXML",
-          "ScoreTable",
-          "SmallScoreTable"
-        ],
-        "Integer": [
-          "UISequence_CustomMTRefTime",
-          "BigMessageSoundVariant",
-          "GaugeClan",
-          "OverlayChatLineCount",
-          "ScoreSummary_Points1",
-          "ScoreSummary_RoundPoints1",
-          "ScoreSummary_MatchPoints1",
-          "ScoreSummary_Points2",
-          "ScoreSummary_RoundPoints2",
-          "ScoreSummary_MatchPoints2",
-          "CountdownEndTime",
-          "AlliesLabelsMaxCount",
-          "SpectatorForceCameraType",
-          "SpectatorForcedClan"
-        ],
-        "EAvatarVariant": [
-          "BigMessageAvatarVariant"
-        ],
-        "EUISound": [
-          "BigMessageSound"
-        ],
-        "Real": [
-          "GaugeRatio",
-          "ScoreSummary_Gauge1",
-          "ScoreSummary_Gauge2",
-          "SpectatorCamAutoLatitude",
-          "SpectatorCamAutoLongitude",
-          "SpectatorCamAutoRadius"
-        ],
-        "CUILayer[]": [
-          "UILayers"
-        ],
-        "Vec2": [
-          "OverlayChatOffset",
-          "CountdownCoord"
-        ],
-        "ENoticeLevel": [
-          "NoticesFilter_LevelToShowAsBigMessage"
-        ],
-        "EVisibility": [
-          "ScoreTableVisibility",
-          "SmallScoreTableVisibility",
-          "AlliesLabelsShowGauges",
-          "AlliesLabelsShowNames",
-          "TeamLabelsShowGauges",
-          "TeamLabelsShowNames",
-          "OpposingTeamLabelsShowGauges",
-          "OpposingTeamLabelsShowNames"
-        ],
-        "Ident": [
-          "ScoreSummary_Player1",
-          "ScoreSummary_Player2",
-          "SpectatorAutoTarget",
-          "SpectatorForcedTarget"
-        ],
-        "EUIStatus": [
-          "UIStatus"
-        ],
-        "ELabelsVisibility": [
-          "AlliesLabelsVisibility",
-          "TeamLabelsVisibility",
-          "OpposingTeamLabelsVisibility"
-        ],
-        "EObserverMode": [
-          "SpectatorObserverMode"
-        ]
-      },
-      "methods": {
-        "SendChat": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SendNotice": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            },
-            {
-              "identifier": "ENoticeLevel",
-              "argument": "Level"
-            },
-            {
-              "identifier": "CUser",
-              "argument": "Avatar"
-            },
-            {
-              "identifier": "EAvatarVariant",
-              "argument": "AvatarVariant"
-            },
-            {
-              "identifier": "EUISound",
-              "argument": "Sound"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SoundVariant"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetLayerManialinkAction": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            }
-          ],
-          "returns": "Text"
-        },
-        "ClearLayerManialinkAction": {
-          "params": [
-            {
-              "identifier": "CUILayer",
-              "argument": "Layer"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CTmResult": {
-      "props": {
-        "Integer": [
-          "Time",
-          "StuntsScore",
-          "NbRespawns"
-        ],
-        "Integer[]": [
-          "Checkpoints"
-        ]
-      },
-      "methods": {
-        "Compare": {
-          "params": [
-            {
-              "identifier": "CTmResult",
-              "argument": "Other"
-            },
-            {
-              "identifier": "ETmRaceResultCriteria",
-              "argument": "Criteria"
-            }
-          ],
-          "returns": "Integer"
-        }
-      }
-    },
-    "CXmlNode": {
-      "props": {
-        "Text": [
-          "Name",
-          "TextContents",
-          "TextRawContents",
-          "TextRecursiveContents"
-        ],
-        "CXmlNode[]": [
-          "Children"
-        ]
-      },
-      "methods": {
-        "GetAttributeText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            },
-            {
-              "identifier": "Text",
-              "argument": "DefaultValue"
-            }
-          ],
-          "returns": "Text"
-        },
-        "GetAttributeInteger": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "DefaultValue"
-            }
-          ],
-          "returns": "Integer"
-        },
-        "GetAttributeReal": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            },
-            {
-              "identifier": "Real",
-              "argument": "DefaultValue"
-            }
-          ],
-          "returns": "Real"
-        },
-        "GetAttributeBoolean": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "DefaultValue"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Name"
-            }
-          ],
-          "returns": "CXmlNode"
-        }
-      }
-    },
-    "CXmlRpcEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "Text": [
-          "Param1",
-          "Param2",
-          "ParamArray1"
-        ],
-        "Text[]": [
-          "ParamArray2"
-        ]
-      }
-    },
-    "MathLib": {
-      "props": {},
-      "methods": {}
-    },
-    "TextLib": {
-      "props": {},
-      "methods": {}
-    },
-    "MapUnits": {
-      "props": {},
-      "methods": {}
-    },
-    "AnimLib": {
-      "props": {},
-      "methods": {}
-    }
-  }
+	"primitives": [
+		"Boolean",
+		"Ident",
+		"Int3",
+		"Integer",
+		"Real",
+		"Text",
+		"Vec2",
+		"Vec3",
+		"Void"
+	],
+	"classes": {
+		"CAchievementsAchievement": {
+			"props": {
+				"CAchievementsAchievementDesc": [
+					"AchievementDesc"
+				],
+				"Ident": [
+					"UserId"
+				]
+			},
+			"methods": []
+		},
+		"CAchievementsAchievementDesc": {
+			"props": {
+				"Text": [
+					"Description",
+					"DisplayName",
+					"IconUrl",
+					"TitleId"
+				]
+			},
+			"methods": []
+		},
+		"CAchievementsEvent": {
+			"props": {
+				"CAchievementsAchievement": [
+					"Achievement"
+				],
+				"EType": [
+					"Type"
+				]
+			},
+			"methods": []
+		},
+		"CAchievementsManager": {
+			"props": {
+				"CAchievementsAchievement[]": [
+					"Achievements"
+				],
+				"CAchievementsAchievementDesc[]": [
+					"AchievementDescriptions"
+				],
+				"CAchievementsEvent[]": [
+					"PendingEvents"
+				],
+				"CAchievementsStat[]": [
+					"Stats"
+				],
+				"CAchievementsStatDesc[]": [
+					"StatDescriptions"
+				]
+			},
+			"methods": [
+				{
+					"name": "SendEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mnemo"
+						},
+						{
+							"identifier": "Integer[]",
+							"argument": "Params"
+						}
+					]
+				}
+			]
+		},
+		"CAchievementsStat": {
+			"props": {
+				"CAchievementsStatDesc": [
+					"StatDesc"
+				],
+				"Ident": [
+					"UserId"
+				],
+				"Integer": [
+					"Value"
+				]
+			},
+			"methods": []
+		},
+		"CAchievementsStatDesc": {
+			"props": {
+				"Text": [
+					"Description",
+					"DisplayName",
+					"TitleId"
+				]
+			},
+			"methods": []
+		},
+		"CAnchorData": {
+			"props": {
+				"CBlock": [
+					"Block"
+				],
+				"CItemAnchor": [
+					"Item"
+				],
+				"Integer": [
+					"DefaultOrder",
+					"Order"
+				],
+				"Text": [
+					"DefaultTag",
+					"Tag"
+				]
+			},
+			"methods": []
+		},
+		"CAnimManager": {
+			"props": {},
+			"methods": [
+				{
+					"name": "Add",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMlControl",
+							"argument": "Control"
+						},
+						{
+							"identifier": "Text",
+							"argument": "XmlTarget"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "StartTime"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Duration"
+						},
+						{
+							"identifier": "EAnimManagerEasing",
+							"argument": "EasingFunc"
+						}
+					]
+				},
+				{
+					"name": "AddChain",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMlControl",
+							"argument": "Control"
+						},
+						{
+							"identifier": "Text",
+							"argument": "XmlTarget"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Duration"
+						},
+						{
+							"identifier": "EAnimManagerEasing",
+							"argument": "EasingFunc"
+						}
+					]
+				},
+				{
+					"name": "Add",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMlControl",
+							"argument": "Control"
+						},
+						{
+							"identifier": "Text",
+							"argument": "XmlTarget"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Duration"
+						},
+						{
+							"identifier": "EAnimManagerEasing",
+							"argument": "EasingFunc"
+						}
+					]
+				}
+			]
+		},
+		"CAnyEditorPlugin": {
+			"props": {
+				"CEditorEditor": [
+					"EditorEditor"
+				],
+				"CEditorMesh": [
+					"MeshEditor"
+				],
+				"CEditorModule": [
+					"ModuleEditor"
+				],
+				"CManiaAppEvent[]": [
+					"PendingEvents"
+				],
+				"EInteractionStatus": [
+					"InteractionStatus"
+				]
+			},
+			"methods": []
+		},
+		"CAudioManager": {
+			"props": {
+				"Boolean": [
+					"ForceEnableMusic"
+				],
+				"CAudioSource[]": [
+					"Sounds"
+				],
+				"Real": [
+					"LimitMusicVolumedB",
+					"LimitSceneSoundVolumedB",
+					"LimitUiSoundVolumedB"
+				]
+			},
+			"methods": [
+				{
+					"name": "CreateSound",
+					"returns": "CAudioSource",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "CreateSound",
+					"returns": "CAudioSource",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsMusic"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsLooping"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsSpatialized"
+						}
+					]
+				},
+				{
+					"name": "DestroySound",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSource",
+							"argument": "Sound"
+						}
+					]
+				},
+				{
+					"name": "CreateMusic",
+					"returns": "CAudioSourceMusic",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "DestroyMusic",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSourceMusic",
+							"argument": "Music"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSource",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ELibSound",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SoundVariant"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSource",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Delay"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Delay"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ELibSound",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SoundVariant"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Delay"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSource",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PanRadiusLfe"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PanRadiusLfe"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CAudioSource",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PanRadiusLfe"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Delay"
+						}
+					]
+				},
+				{
+					"name": "PlaySoundEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Real",
+							"argument": "VolumedB"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PanRadiusLfe"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Delay"
+						}
+					]
+				},
+				{
+					"name": "ClearAllDelayedSoundsEvents",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CAudioSource": {
+			"props": {
+				"Boolean": [
+					"DownloadInProgress",
+					"IsPlaying"
+				],
+				"Real": [
+					"FadeDuration",
+					"Pitch",
+					"PlayCursor",
+					"PlayLength",
+					"Volume",
+					"VolumedB"
+				],
+				"Vec3": [
+					"PanRadiusLfe",
+					"RelativePosition"
+				]
+			},
+			"methods": [
+				{
+					"name": "Play",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Stop",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CAudioSourceMusic": {
+			"props": {
+				"Boolean": [
+					"Dbg_ForceIntensity",
+					"Dbg_ForceRandom",
+					"Dbg_ForceSequential",
+					"UseNewImplem"
+				],
+				"EUpdateMode": [
+					"UpdateMode"
+				],
+				"Integer": [
+					"BeatsPerBar",
+					"Tracks_Count"
+				],
+				"Real": [
+					"BeatDuration",
+					"BeatsPerMinute",
+					"FadeFiltersDuration",
+					"FadeTracksDuration",
+					"HPF_CutoffRatio",
+					"HPF_Q",
+					"LPF_CutoffRatio",
+					"LPF_Q"
+				],
+				"Real[]": [
+					"Tracks_Length",
+					"Tracks_Volume",
+					"Tracks_VolumedB"
+				],
+				"Text[]": [
+					"Tracks_Name"
+				]
+			},
+			"methods": [
+				{
+					"name": "MuteAllTracks",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "UnmuteAllTracks",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "NextVariant",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "NextVariant",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsIntensityDecreasing"
+						}
+					]
+				},
+				{
+					"name": "EnableSegment",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "SegmentName"
+						}
+					]
+				}
+			]
+		},
+		"CBadge": {
+			"props": {
+				"Text": [
+					"SkinName"
+				],
+				"Text[]": [
+					"Layers"
+				],
+				"Vec3": [
+					"PrimaryColor"
+				]
+			},
+			"methods": [
+				{
+					"name": "StickerSlot_Get",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Slot"
+						}
+					]
+				},
+				{
+					"name": "StickerSlot_Set",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Slot"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Sticker"
+						}
+					]
+				},
+				{
+					"name": "StickerSlot_Clear",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CBadgeEditor": {
+			"props": {
+				"CBadge": [
+					"DisplayCurrentBadge"
+				],
+				"CBadge[]": [
+					"Badges"
+				],
+				"Ident": [
+					"DisplayCurrentMeshId"
+				],
+				"Ident[]": [
+					"MeshIds"
+				],
+				"Real": [
+					"CameraTransitionDuration",
+					"DisplayFoV",
+					"MeshRotation_Acceleration",
+					"MeshRotation_MaxSpeed"
+				],
+				"Vec2": [
+					"DisplayPosN",
+					"DisplaySize"
+				]
+			},
+			"methods": [
+				{
+					"name": "Leave",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "MeshId_Next",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "MeshId_Previous",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BadgeCreate",
+					"returns": "CBadge",
+					"params": []
+				},
+				{
+					"name": "BadgeDestroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						}
+					]
+				},
+				{
+					"name": "BadgeCopy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Source"
+						},
+						{
+							"identifier": "CBadge",
+							"argument": "Destination"
+						}
+					]
+				},
+				{
+					"name": "BadgeReadFromProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "BadgeWriteToProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				}
+			]
+		},
+		"CBadgeManager": {
+			"props": {
+				"CBadge[]": [
+					"Badges"
+				]
+			},
+			"methods": [
+				{
+					"name": "BadgeCreate",
+					"returns": "CBadge",
+					"params": []
+				},
+				{
+					"name": "BadgeDestroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						}
+					]
+				},
+				{
+					"name": "BadgeCopy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Source"
+						},
+						{
+							"identifier": "CBadge",
+							"argument": "Destination"
+						}
+					]
+				},
+				{
+					"name": "BadgeReadFromProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "BadgeWriteToProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBadge",
+							"argument": "Badge"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "ProfileIsReady",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				}
+			]
+		},
+		"CBlock": {
+			"props": {
+				"Boolean": [
+					"CanHaveAnchor"
+				],
+				"CBlockModel": [
+					"BlockModel"
+				],
+				"CBlockUnit[]": [
+					"BlockUnits"
+				],
+				"CardinalDirections": [
+					"Direction"
+				],
+				"Int3": [
+					"Coord"
+				],
+				"Integer": [
+					"BlockScriptId"
+				]
+			},
+			"methods": [
+				{
+					"name": "UseDefaultAnchor",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "UseCustomAnchor",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CBlockModel": {
+			"props": {
+				"Boolean": [
+					"IsPodium",
+					"IsRoad",
+					"IsTerrain",
+					"NoRespawn"
+				],
+				"CBlockModelVariantAir": [
+					"VariantAir"
+				],
+				"CBlockModelVariantGround": [
+					"VariantGround"
+				],
+				"EWayPointType": [
+					"WaypointType"
+				],
+				"Text": [
+					"Name"
+				]
+			},
+			"methods": []
+		},
+		"CBlockModelClip": {
+			"props": {},
+			"methods": []
+		},
+		"CBlockModelVariant": {
+			"props": {
+				"Boolean": [
+					"IsAllUnderground",
+					"IsPartUnderground"
+				],
+				"CBlockUnitModel[]": [
+					"BlockUnitModels"
+				],
+				"Int3": [
+					"OffsetBoundingBoxMax",
+					"OffsetBoundingBoxMin",
+					"Size"
+				],
+				"Text": [
+					"Name"
+				]
+			},
+			"methods": []
+		},
+		"CBlockModelVariantAir": {
+			"props": {},
+			"methods": []
+		},
+		"CBlockModelVariantGround": {
+			"props": {},
+			"methods": []
+		},
+		"CBlockUnit": {
+			"props": {
+				"CBlock": [
+					"Block",
+					"BlockUnitModel"
+				],
+				"Int3": [
+					"AbsoluteOffset"
+				]
+			},
+			"methods": []
+		},
+		"CBlockUnitModel": {
+			"props": {
+				"CBlockModelClip[]": [
+					"Clips"
+				],
+				"Int3": [
+					"RelativeOffset"
+				]
+			},
+			"methods": []
+		},
+		"CCampaign": {
+			"props": {
+				"Boolean": [
+					"OfficialRecordEnabled"
+				],
+				"CMapGroup[]": [
+					"MapGroups"
+				],
+				"Text": [
+					"CampaignId",
+					"ScoreContext"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetMapGroupCount",
+					"returns": "Integer",
+					"params": []
+				},
+				{
+					"name": "GetMapGroup",
+					"returns": "CMapGroup",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Index"
+						}
+					]
+				},
+				{
+					"name": "GetNextMap",
+					"returns": "CMapInfo",
+					"params": [
+						{
+							"identifier": "CMapInfo",
+							"argument": "CurrentMapInfo"
+						}
+					]
+				}
+			]
+		},
+		"CClient": {
+			"props": {
+				"Boolean": [
+					"IsConnectedToMasterServer",
+					"IsSpectator"
+				],
+				"CUIConfig": [
+					"UI"
+				],
+				"CUser": [
+					"User"
+				],
+				"Integer": [
+					"IdleDuration"
+				],
+				"Text": [
+					"ClientTitleVersion",
+					"ClientVersion"
+				]
+			},
+			"methods": []
+		},
+		"CCollector": {
+			"props": {
+				"CImage": [
+					"Icon"
+				],
+				"Integer": [
+					"InterfaceNumber"
+				],
+				"Text": [
+					"Name",
+					"PageName"
+				]
+			},
+			"methods": []
+		},
+		"CDataFileMgr": {
+			"props": {
+				"CCampaign[]": [
+					"Campaigns"
+				],
+				"CGhost[]": [
+					"Ghosts"
+				],
+				"CTaskResult[]": [
+					"TaskResults"
+				]
+			},
+			"methods": [
+				{
+					"name": "TaskResult_Release",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TaskId"
+						}
+					]
+				},
+				{
+					"name": "Campaign_Get",
+					"returns": "CCampaign",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						}
+					]
+				},
+				{
+					"name": "Map_RefreshFromDisk",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Map_GetUserList",
+					"returns": "CTaskResult_MapList",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "Map_GetGameList",
+					"returns": "CTaskResult_MapList",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Map_GetFilteredGameList",
+					"returns": "CTaskResult_MapList",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Scope"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Ghost_Release",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostId"
+						}
+					]
+				},
+				{
+					"name": "Ghost_Download",
+					"returns": "CTaskResult_Ghost",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "Replay_RefreshFromDisk",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Replay_GetGameList",
+					"returns": "CTaskResult_ReplayList",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Replay_GetFilteredGameList",
+					"returns": "CTaskResult_ReplayList",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Scope"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Replay_Load",
+					"returns": "CTaskResult_GhostList",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						}
+					]
+				},
+				{
+					"name": "Replay_Save",
+					"returns": "CTaskResult",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "CMap",
+							"argument": "Map"
+						},
+						{
+							"identifier": "CGhost",
+							"argument": "Ghost"
+						}
+					]
+				},
+				{
+					"name": "Media_GetGameList",
+					"returns": "CTaskResult_FileList",
+					"params": [
+						{
+							"identifier": "EMediaType",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Media_GetFilteredGameList",
+					"returns": "CTaskResult_FileList",
+					"params": [
+						{
+							"identifier": "EMediaType",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Scope"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "GameMode_GetGameList",
+					"returns": "CTaskResult_GameModeList",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Scope"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Flatten"
+						}
+					]
+				},
+				{
+					"name": "Pack_DownloadOrUpdate",
+					"returns": "CTaskResult",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "DisplayName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				}
+			]
+		},
+		"CEditorAsset": {
+			"props": {},
+			"methods": []
+		},
+		"CEditorEditor": {
+			"props": {
+				"Boolean": [
+					"Bindings_RequestInput_Done"
+				],
+				"CEditorEvent[]": [
+					"PendingEvents"
+				],
+				"Text[]": [
+					"BindingContexts",
+					"RequestedContextBindings"
+				]
+			},
+			"methods": [
+				{
+					"name": "Bindings_AddContext",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_AddBinding",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "BindingScriptId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "BindingDisplayName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_RemoveContext",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_RemoveBinding",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_RequestInput",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_SetBindingScriptId",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingScriptId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "NewBindingScriptId"
+						}
+					]
+				},
+				{
+					"name": "Bindings_SetBindingDisplayName",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingScriptId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "BindingDisplayName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_SetContextName",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "NewContextName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_GetContextBindings",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_GetBindingActionName",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingName"
+						}
+					]
+				},
+				{
+					"name": "Bindings_GetBindingDisplayName",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingName"
+						}
+					]
+				}
+			]
+		},
+		"CEditorEvent": {
+			"props": {
+				"Type": [
+					"Type"
+				]
+			},
+			"methods": []
+		},
+		"CEditorMainPlugin": {
+			"props": {
+				"CEditorPluginHandle[]": [
+					"Plugins"
+				]
+			},
+			"methods": [
+				{
+					"name": "Help_Open",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Help_Close",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "GetPluginHandle",
+					"returns": "CEditorPluginHandle",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						}
+					]
+				},
+				{
+					"name": "SendPluginEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CEditorPluginHandle",
+							"argument": "Handle"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "Context_SetActive",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsActive"
+						}
+					]
+				},
+				{
+					"name": "Context_IsActive",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ContextName"
+						}
+					]
+				},
+				{
+					"name": "Binding_IsActive",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BindingName"
+						}
+					]
+				},
+				{
+					"name": "Plugin_SetClearance",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CEditorPluginHandle",
+							"argument": "Handle"
+						},
+						{
+							"identifier": "EMeshEditorAPI",
+							"argument": "API"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsAllowed"
+						}
+					]
+				}
+			]
+		},
+		"CEditorMesh": {
+			"props": {
+				"Boolean": [
+					"DisplayFaces",
+					"DisplayJoints",
+					"DisplayVertices",
+					"Display_HideElemsByDistance_IsActive",
+					"EditionBox_IsPlaneOriented",
+					"GoToMaterialEditor",
+					"GridSnap_IsActive",
+					"IsCreateMaterial",
+					"IsExperimental",
+					"Tmp_UseParts"
+				],
+				"CEditorEvent[]": [
+					"PendingEvents"
+				],
+				"EEdgesDisplay": [
+					"DisplayEdges"
+				],
+				"EInteraction": [
+					"CurrentInteraction"
+				],
+				"Ident": [
+					"SelectionSet"
+				],
+				"Ident[]": [
+					"MaterialIds"
+				],
+				"Integer": [
+					"CreationElemsCount",
+					"Display_HideElemsByDistance_Distance",
+					"EdgeCount",
+					"FaceCount",
+					"Material_Atlas_SelectedSubTexIndex",
+					"MaterialsUpdateId",
+					"PrefabNamesUpdateId",
+					"RotationStep",
+					"VertexCount"
+				],
+				"Real": [
+					"Display_HideElemsByDistance_Opacity",
+					"RotationValue",
+					"Scale",
+					"ScalingRatio",
+					"ScalingStep",
+					"Size",
+					"Step"
+				],
+				"Text[]": [
+					"MaterialNames",
+					"PrefabNames"
+				]
+			},
+			"methods": [
+				{
+					"name": "EditionBox_SetScale",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "Scale"
+						}
+					]
+				},
+				{
+					"name": "EditionBox_OrientPlane",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "EditedMesh_Clear",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "EditedMesh_Simplify",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "EditedMesh_Lod",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "Faces"
+						}
+					]
+				},
+				{
+					"name": "UVUnwrap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "ETexCoordLayer",
+							"argument": "ETexCoordLayer"
+						}
+					]
+				},
+				{
+					"name": "Undo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Redo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SwitchPlane",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "GridSnap_SetActive",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsActive"
+						}
+					]
+				},
+				{
+					"name": "PickInfo_GetNormal",
+					"returns": "Vec3",
+					"params": []
+				},
+				{
+					"name": "PickInfo_GetPosition",
+					"returns": "Vec3",
+					"params": []
+				},
+				{
+					"name": "PickInfo_GetEdgeLength",
+					"returns": "Real",
+					"params": []
+				},
+				{
+					"name": "PickInfo_GetNextVertexPosition",
+					"returns": "Vec3",
+					"params": []
+				},
+				{
+					"name": "PickInfo_GetMaterial",
+					"returns": "Ident",
+					"params": []
+				},
+				{
+					"name": "PickInfo_GetError",
+					"returns": "Text",
+					"params": []
+				},
+				{
+					"name": "Part_SetAnchorPos",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						}
+					]
+				},
+				{
+					"name": "Part_SetIsJoint",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsJoint"
+						}
+					]
+				},
+				{
+					"name": "Part_ClearAnchor",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Material_GetMaterialIdSelected",
+					"returns": "Ident",
+					"params": []
+				},
+				{
+					"name": "Material_SetMaterialIdSelected",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialEditorId"
+						}
+					]
+				},
+				{
+					"name": "Material_GetSubTexIndexSelected",
+					"returns": "Integer",
+					"params": []
+				},
+				{
+					"name": "Material_MaterialLibGetCount",
+					"returns": "Integer",
+					"params": []
+				},
+				{
+					"name": "Material_SetDefault",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						}
+					]
+				},
+				{
+					"name": "Material_GetDefault",
+					"returns": "Ident",
+					"params": []
+				},
+				{
+					"name": "Material_GetBitmapBase",
+					"returns": "CImage",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						}
+					]
+				},
+				{
+					"name": "Material_GetBitmap",
+					"returns": "CImage",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						}
+					]
+				},
+				{
+					"name": "Material_MatchesCriterion",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						},
+						{
+							"identifier": "EMaterialFilterCriterion",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Material_SetFilter",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EMaterialFilterCriterion",
+							"argument": "Criterion"
+						},
+						{
+							"identifier": "EFilterKind",
+							"argument": "FilterKind"
+						}
+					]
+				},
+				{
+					"name": "Material_GetFilter",
+					"returns": "EFilterKind",
+					"params": [
+						{
+							"identifier": "EMaterialFilterCriterion",
+							"argument": "Criterion"
+						}
+					]
+				},
+				{
+					"name": "Material_ClearFilters",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Material_UVEditor_SetIsRotation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsRotation"
+						}
+					]
+				},
+				{
+					"name": "Material_UVEditor_SetIsScale",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsScale"
+						}
+					]
+				},
+				{
+					"name": "Material_UVEditor_SetIsScale1D",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsScale"
+						}
+					]
+				},
+				{
+					"name": "Material_UVEditor_Open",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						},
+						{
+							"identifier": "CMlQuad",
+							"argument": "LocationQuad"
+						}
+					]
+				},
+				{
+					"name": "Material_UVEditor_Close",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Material_UVEditor_SetMode",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EUVEditorMode",
+							"argument": "Mode"
+						}
+					]
+				},
+				{
+					"name": "Material_UVEditor_GetMode",
+					"returns": "EUVEditorMode",
+					"params": []
+				},
+				{
+					"name": "Material_UVEditor_SetProjectionType",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EUVEditorProjectionType",
+							"argument": "ProjectionType"
+						}
+					]
+				},
+				{
+					"name": "Material_IsGameMaterial",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "Material_UVEditor_Apply",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Material_PasteMaterial",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Abort",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_SetPreview",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetToPreview"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartCreation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "CreationSetHandle"
+						},
+						{
+							"identifier": "EElemType",
+							"argument": "ElemType"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SetToPickFromHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Creation_GetElems",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_CloseCreation",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_Creation_ClearParams",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_Creation_SetEdgesConstraint",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EEdgesConstraint",
+							"argument": "EdgesConstraint"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Creation_SetAutoMerge",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "AutoMerge"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPaste",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_StartBlocTransformation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TransformationSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartCurve2D",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BordersSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_CloseCurve2D",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "CanDoCurve2D"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPick",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EElemType",
+							"argument": "ElemType"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SetToPickFrom"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPickJoint",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_StartMerge",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "MergeSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartMirror",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Selection_ClearParams",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_Selection_SetUseParts",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "UseParts"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Selection_SetCanEnterLeaf",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "CanEnterLeaf"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartSelection",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SelectionSetHandle"
+						},
+						{
+							"identifier": "EElemType",
+							"argument": "ElemType"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SelectionSetToPickFrom"
+						}
+					]
+				},
+				{
+					"name": "Interaction_CloseSelection",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Interaction_StartTranslation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TranslationSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPickTranslation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TranslationSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartRotation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "RotationSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPickRotation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "RotationSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Rotation_SetStep",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "RotationStep"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartPickScale",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ScalingSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Interaction_Scale_SetStep",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "ScalingStep"
+						}
+					]
+				},
+				{
+					"name": "Interaction_StartSplit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Display_HighlightSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "Display_ClearHighlighting",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Display_AtlasSelectionsSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "DisplayAtlasSelection"
+						}
+					]
+				},
+				{
+					"name": "Display_AtlasSelectionsGet",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "Display_HideElemsByDistance_Start",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "Display_HideElemsByDistance_Stop",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Display_HideMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Display_ShowMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "MergeAllSuperposedElements",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "Selection_Undo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Selection_Redo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetOfElements_Create",
+					"returns": "Ident",
+					"params": []
+				},
+				{
+					"name": "SetOfElements_CopyFrom",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "DestinationSet"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SourceSet"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_Append",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "DestinationSet"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SourceSet"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_Destroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_Empty",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_SetAllElements",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_SetAllFaces",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_DeleteElements",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_HasHorizontalFaces",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_HasVerticalFaces",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_GetElemsCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_GetVerticesCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_GetEdgesCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_GetFacesCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "ExtendSelectedSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "GetBordersSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SetBordersHandle"
+						}
+					]
+				},
+				{
+					"name": "GetBordersVertexs",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "SetVertexHandle"
+						}
+					]
+				},
+				{
+					"name": "SelectionSet_SelectAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Curve2DPolygon",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "FourVertexSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "Sethandle"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SubTexIndex"
+						}
+					]
+				},
+				{
+					"name": "AtlasSelection_Create",
+					"returns": "Ident",
+					"params": []
+				},
+				{
+					"name": "AtlasSelection_GetAtlasSelectionHandleFromSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "AtlasSelections_AddAtlasSelectionFromSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "FourPointsHandle"
+						}
+					]
+				},
+				{
+					"name": "AtlasSelections_SubAtlasSelection",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "AtlasSelections_TextureAtlasSelection",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SubTexIndex"
+						}
+					]
+				},
+				{
+					"name": "AtlasSelections_GetAtlasSelectionAfterSelection",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "Sethandle"
+						}
+					]
+				},
+				{
+					"name": "Preview_Clear",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BlocTransformation_Start",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "BlocTransformation_Translate",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Translation"
+						}
+					]
+				},
+				{
+					"name": "BlocTransformation_Twist",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "Angle"
+						}
+					]
+				},
+				{
+					"name": "BlocTransformation_Bend",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Axis"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Radius"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Angle"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Direction"
+						}
+					]
+				},
+				{
+					"name": "BlocTransformation_Abort",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BlocTransformation_Close",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "VoxelSpace_Init",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Size"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseColors"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_Destroy",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "VoxelSpace_Get",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Pos"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_Set",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Pos"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_SetVec3",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Pos"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_Set",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Pos"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Color"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_Unset",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Pos"
+						}
+					]
+				},
+				{
+					"name": "VoxelSpace_GenerateMesh",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetOfElements_ProjectOnPlane",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_ProjectOnGround",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Height"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_SplitEdgeWithVertex",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_CollapseEdgeWithVertex",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_Subdivide",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfElements_Subdivide_Interpolation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawCircle",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "InputSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawDisc",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "InputSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawCircle",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "CenterSetHandle"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PointOnCircle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawIcosahedron",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "InputSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawIcosahedron",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "CenterSetHandle"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PointOnCircle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawIcosahedricSphere",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "InputSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawPoly",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "InputSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "VerticesCount"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawPoly",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "CenterSetHandle"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "PointOnPoly"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "VerticesCount"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawSpline",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ControlSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_Weld",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "VerticesSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfVertices_DrawBox",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ControlSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfEdges_Fill",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfEdges_Flip",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfEdges_BorderExpand",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfOneEdge_FaceLoopExpand",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfOneEdge_EdgeLoopExpand",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfOneFace_CutHole",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "FaceSetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "EdgesSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfFaces_Extrude",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfFaces_QuadsToTriangles",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ResultSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfFaces_ApplyMaterial",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "SetHandle"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "MaterialId"
+						}
+					]
+				},
+				{
+					"name": "SetOfFaces_PlanarExpand",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "FacesSetHandle"
+						}
+					]
+				},
+				{
+					"name": "SetOfFaces_ChangeOrientation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "FacesSetHandle"
+						}
+					]
+				},
+				{
+					"name": "Prefab_Export",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Prefab_Import",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "PrefabIndex"
+						}
+					]
+				},
+				{
+					"name": "Parts_MergeSelectedParts",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Parts_Group",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Parts_UngroupSelectedParts",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Cut",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Copy",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetBaseUndoState",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "AddUndoState",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "AutoSave",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				}
+			]
+		},
+		"CEditorModule": {
+			"props": {
+				"CEditorPluginModuleEvent[]": [
+					"PendingEvents"
+				],
+				"CModuleMenuModel": [
+					"EditedMenu"
+				],
+				"CModuleMenuPageModel": [
+					"EditedMenuPage"
+				]
+			},
+			"methods": [
+				{
+					"name": "NewModule",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EModuleType",
+							"argument": "ModuleType"
+						}
+					]
+				},
+				{
+					"name": "OpenModule",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "Save",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SaveAs",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "SaveCopyAs",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "ForceExit",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CEditorPluginHandle": {
+			"props": {},
+			"methods": []
+		},
+		"CEditorPluginModuleEvent": {
+			"props": {
+				"Type": [
+					"Type"
+				]
+			},
+			"methods": [
+				{
+					"name": "Eat",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CGameEditorParent": {
+			"props": {},
+			"methods": []
+		},
+		"CGameMatchSettingsPlaylistItemScript": {
+			"props": {
+				"Boolean": [
+					"FileExists"
+				],
+				"Text": [
+					"Name"
+				]
+			},
+			"methods": []
+		},
+		"CGameModeInfo": {
+			"props": {
+				"Text": [
+					"Description",
+					"Name",
+					"Path",
+					"Version"
+				],
+				"Text[]": [
+					"CompatibleMapTypes"
+				]
+			},
+			"methods": []
+		},
+		"CGamePlayerMapRecordScript": {
+			"props": {
+				"Integer": [
+					"MultiAsyncLevel",
+					"RespawnCount",
+					"Score",
+					"SkillPoints",
+					"Time",
+					"Timestamp"
+				],
+				"Text": [
+					"Context",
+					"FileName",
+					"MapName",
+					"MapUid",
+					"ReplayUrl"
+				]
+			},
+			"methods": []
+		},
+		"CGhost": {
+			"props": {
+				"CTmResult": [
+					"Result"
+				],
+				"Ident": [
+					"Id"
+				],
+				"Text": [
+					"Nickname"
+				]
+			},
+			"methods": []
+		},
+		"CHighScoreComparison": {
+			"props": {
+				"CMapInfo": [
+					"MapInfo"
+				],
+				"Integer": [
+					"OpponentRecordCount",
+					"OpponentRecordDate",
+					"OpponentRecordElapsedTime",
+					"OpponentRecordRespawnCount",
+					"OpponentRecordScore",
+					"OpponentRecordTime",
+					"RecordCount",
+					"RecordDate",
+					"RecordElapsedTime",
+					"RecordRespawnCount",
+					"RecordScore",
+					"RecordTime"
+				],
+				"Text": [
+					"Login",
+					"OpponentDisplayName",
+					"OpponentLogin",
+					"OpponentRecordDateString",
+					"OpponentRecordUrl",
+					"RecordDateString"
+				]
+			},
+			"methods": []
+		},
+		"CHighScoreComparisonSummary": {
+			"props": {
+				"Integer": [
+					"BestRecordCount",
+					"BestRecordElapsedTime",
+					"BestRecordLastDate",
+					"OpponentBestRecordCount",
+					"OpponentBestRecordElapsedTime",
+					"OpponentBestRecordLastDate"
+				],
+				"Text": [
+					"BestRecordLastDateString",
+					"Login",
+					"OpponentBestRecordLastDateString",
+					"OpponentDisplayName",
+					"OpponentLogin"
+				]
+			},
+			"methods": []
+		},
+		"CHttpManager": {
+			"props": {
+				"Boolean": [
+					"AutomaticHeaders_Timezone"
+				],
+				"CHttpRequest[]": [
+					"Requests"
+				],
+				"Integer": [
+					"SlotsAvailable"
+				]
+			},
+			"methods": [
+				{
+					"name": "CreateGet",
+					"returns": "CHttpRequest",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "CreateGet",
+					"returns": "CHttpRequest",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseCache"
+						}
+					]
+				},
+				{
+					"name": "CreateGet",
+					"returns": "CHttpRequest",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseCache"
+						},
+						{
+							"identifier": "Text",
+							"argument": "AdditionalHeaders"
+						}
+					]
+				},
+				{
+					"name": "CreatePost",
+					"returns": "CHttpRequest",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Resource"
+						}
+					]
+				},
+				{
+					"name": "CreatePost",
+					"returns": "CHttpRequest",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Resource"
+						},
+						{
+							"identifier": "Text",
+							"argument": "AdditionalHeaders"
+						}
+					]
+				},
+				{
+					"name": "Destroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CHttpRequest",
+							"argument": "Request"
+						}
+					]
+				},
+				{
+					"name": "IsValidUrl",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				}
+			]
+		},
+		"CHttpRequest": {
+			"props": {
+				"Boolean": [
+					"IsCompleted"
+				],
+				"Integer": [
+					"StatusCode"
+				],
+				"Text": [
+					"Result",
+					"Url"
+				]
+			},
+			"methods": []
+		},
+		"CImage": {
+			"props": {},
+			"methods": []
+		},
+		"CInputEvent": {
+			"props": {
+				"Boolean": [
+					"IsAutoRepeat"
+				],
+				"CInputPad": [
+					"Pad"
+				],
+				"EButton": [
+					"Button"
+				],
+				"EType": [
+					"Type"
+				],
+				"Integer": [
+					"KeyCode"
+				],
+				"Text": [
+					"KeyName"
+				]
+			},
+			"methods": []
+		},
+		"CInputManager": {
+			"props": {
+				"Boolean": [
+					"ExclusiveMode",
+					"MouseLeftButton",
+					"MouseMiddleButton",
+					"MouseRightButton"
+				],
+				"CInputEvent[]": [
+					"PendingEvents"
+				],
+				"CInputPad[]": [
+					"Pads"
+				],
+				"Integer": [
+					"Dbg_AutoRepeat_InitialDelay",
+					"Dbg_AutoRepeat_Period",
+					"Now",
+					"Period"
+				],
+				"Vec2": [
+					"MousePos"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetPadButtonPlaygroundBinding",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CInputPad",
+							"argument": "Pad"
+						},
+						{
+							"identifier": "EButton",
+							"argument": "Button"
+						}
+					]
+				},
+				{
+					"name": "GetPadButtonCurrentBinding",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CInputPad",
+							"argument": "Pad"
+						},
+						{
+							"identifier": "EButton",
+							"argument": "Button"
+						}
+					]
+				},
+				{
+					"name": "GetPadButtonBinding",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CInputPad",
+							"argument": "Pad"
+						},
+						{
+							"identifier": "EButton",
+							"argument": "Button"
+						}
+					]
+				},
+				{
+					"name": "IsKeyPressed",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "KeyCode"
+						}
+					]
+				}
+			]
+		},
+		"CInputPad": {
+			"props": {
+				"EButton[]": [
+					"ButtonEvents"
+				],
+				"EPadType": [
+					"Type"
+				],
+				"Ident": [
+					"UserId"
+				],
+				"Integer": [
+					"A",
+					"B",
+					"ControllerId",
+					"Down",
+					"IdleDuration",
+					"L1",
+					"Left",
+					"LeftStickBut",
+					"Menu",
+					"R1",
+					"Right",
+					"RightStickBut",
+					"Up",
+					"View",
+					"X",
+					"Y"
+				],
+				"Real": [
+					"L2",
+					"LeftStickX",
+					"LeftStickY",
+					"R2",
+					"RightStickX",
+					"RightStickY"
+				],
+				"Text": [
+					"ModelName"
+				]
+			},
+			"methods": [
+				{
+					"name": "ClearRumble",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "AddRumble",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Duration"
+						},
+						{
+							"identifier": "Real",
+							"argument": "LargeMotor"
+						},
+						{
+							"identifier": "Real",
+							"argument": "SmallMotor"
+						}
+					]
+				},
+				{
+					"name": "SetColor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Color"
+						}
+					]
+				}
+			]
+		},
+		"CItemAnchor": {
+			"props": {
+				"Vec3": [
+					"Position"
+				]
+			},
+			"methods": []
+		},
+		"CMacroblockModel": {
+			"props": {
+				"Boolean": [
+					"HasCheckpoint",
+					"HasFinish",
+					"HasMultilap",
+					"HasStart",
+					"IsGround"
+				],
+				"CBlockModel": [
+					"GeneratedBlockModel"
+				],
+				"Text": [
+					"Name"
+				]
+			},
+			"methods": [
+				{
+					"name": "ClearScriptMetadata",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CManiaApp": {
+			"props": {
+				"Boolean": [
+					"EnableMenuNavigationInputs",
+					"IsVisible"
+				],
+				"CAudioManager": [
+					"Audio"
+				],
+				"CDataFileMgr": [
+					"DataFileMgr"
+				],
+				"CHttpManager": [
+					"Http"
+				],
+				"CInputManager": [
+					"Input"
+				],
+				"CPresenceMgr": [
+					"PresenceMgr"
+				],
+				"CPrivilegeMgr": [
+					"PrivilegeMgr"
+				],
+				"CScoreMgr": [
+					"ScoreMgr"
+				],
+				"CTitle": [
+					"LoadedTitle"
+				],
+				"CUILayer[]": [
+					"UILayers"
+				],
+				"CUser": [
+					"LocalUser",
+					"UserMgr"
+				],
+				"CVideoManager": [
+					"Video"
+				],
+				"CXmlManager": [
+					"Xml"
+				],
+				"ESystemPlatform": [
+					"SystemPlatform"
+				],
+				"ESystemSkuIdentifier": [
+					"SystemSkuIdentifier"
+				],
+				"Integer": [
+					"CurrentDate",
+					"LayersDefaultManialinkVersion",
+					"Now"
+				],
+				"Text": [
+					"CurrentLocalDateText",
+					"CurrentTimezone",
+					"ManiaAppBaseUrl",
+					"ManiaAppUrl"
+				]
+			},
+			"methods": [
+				{
+					"name": "UILayerCreate",
+					"returns": "CUILayer",
+					"params": []
+				},
+				{
+					"name": "UILayerDestroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUILayer",
+							"argument": "Layer"
+						}
+					]
+				},
+				{
+					"name": "UILayerDestroyAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "LayerCustomEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUILayer",
+							"argument": "Layer"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "OpenLink",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "ELinkType",
+							"argument": "LinkType"
+						}
+					]
+				},
+				{
+					"name": "OpenFileInExplorer",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "Dialog_Message",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Message"
+						}
+					]
+				},
+				{
+					"name": "Dbg_DumpDeclareForVariables",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CNod",
+							"argument": "Nod"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "StatsOnly"
+						}
+					]
+				}
+			]
+		},
+		"CManiaAppBase": {
+			"props": {
+				"CManiaAppEvent[]": [
+					"PendingEvents"
+				]
+			},
+			"methods": []
+		},
+		"CManiaAppBrowser": {
+			"props": {
+				"CManiaAppEvent[]": [
+					"PendingEvents"
+				],
+				"Text": [
+					"BrowserFocusedFrameId"
+				]
+			},
+			"methods": [
+				{
+					"name": "BrowserBack",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserQuit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserHome",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserReload",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CManiaAppEvent": {
+			"props": {
+				"Boolean": [
+					"IsActionAutoRepeat"
+				],
+				"CUILayer": [
+					"CustomEventLayer"
+				],
+				"EMenuNavAction": [
+					"MenuNavAction"
+				],
+				"EType": [
+					"Type"
+				],
+				"Integer": [
+					"KeyCode"
+				],
+				"Text": [
+					"CustomEventType",
+					"ExternalEventType",
+					"KeyName"
+				],
+				"Text[]": [
+					"CustomEventData",
+					"ExternalEventData"
+				]
+			},
+			"methods": []
+		},
+		"CManiaAppPlayground": {
+			"props": {},
+			"methods": [
+				{
+					"name": "SendCustomEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				}
+			]
+		},
+		"CManiaAppPlaygroundCommon": {
+			"props": {
+				"CManiaAppPlaygroundEvent[]": [
+					"PendingEvents"
+				],
+				"CMap": [
+					"Map"
+				],
+				"CPlaygroundClient": [
+					"Playground"
+				],
+				"CUIConfig": [
+					"ClientUI",
+					"UI"
+				]
+			},
+			"methods": []
+		},
+		"CManiaAppPlaygroundEvent": {
+			"props": {
+				"Text": [
+					"PlaygroundScriptEventType"
+				],
+				"Text[]": [
+					"PlaygroundScriptEventData"
+				]
+			},
+			"methods": []
+		},
+		"CManiaAppStation": {
+			"props": {
+				"CPackCreatorTitleInfo[]": [
+					"Maker_EditedTitles"
+				],
+				"CStation": [
+					"Station"
+				]
+			},
+			"methods": [
+				{
+					"name": "EnterStation",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Maker_EditTitle",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "EditedTitleId"
+						}
+					]
+				},
+				{
+					"name": "Maker_EditNewTitle",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "EditedTitleName"
+						}
+					]
+				}
+			]
+		},
+		"CManiaAppTitle": {
+			"props": {
+				"Boolean": [
+					"Authentication_GetTokenResponseReceived",
+					"DontScaleMainMenuForHMD",
+					"LoadingScreenRequireKeyPressed"
+				],
+				"CAchievementsManager": [
+					"AchievementsManager"
+				],
+				"CBadgeManager": [
+					"BadgeManager"
+				],
+				"CManiaAppEvent[]": [
+					"PendingEvents"
+				],
+				"CMatchSettingsManager": [
+					"MatchSettingsManager"
+				],
+				"CNotificationsConsumer": [
+					"Notifications"
+				],
+				"CTitleEdition": [
+					"TitleEdition"
+				],
+				"CTitleFlow": [
+					"TitleControl",
+					"TitleFlow"
+				],
+				"Integer": [
+					"Authentication_ErrorCode"
+				],
+				"Text": [
+					"Authentication_Token",
+					"ExternalRequest_Type"
+				],
+				"Text[]": [
+					"ExternalRequest_Data"
+				]
+			},
+			"methods": [
+				{
+					"name": "Menu_Quit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Home",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Solo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Local",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Internet",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Editor",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Profile",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "PlayMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Map"
+						}
+					]
+				},
+				{
+					"name": "ExternalRequest_Clear",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Authentication_GetToken",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "AppLogin"
+						}
+					]
+				}
+			]
+		},
+		"CManiaAppTitleLayer": {
+			"props": {
+				"CManiaAppTitle": [
+					"ParentApp"
+				],
+				"CTitleFlow": [
+					"TitleControl",
+					"TitleFlow"
+				]
+			},
+			"methods": []
+		},
+		"CMap": {
+			"props": {
+				"Boolean": [
+					"HasCustomIntro",
+					"HasCustomMusic",
+					"TMObjective_IsLapRace"
+				],
+				"CMapInfo": [
+					"MapInfo"
+				],
+				"Int3": [
+					"Size"
+				],
+				"Integer": [
+					"CopperPrice",
+					"TMObjective_AuthorTime",
+					"TMObjective_BronzeTime",
+					"TMObjective_GoldTime",
+					"TMObjective_NbLaps",
+					"TMObjective_SilverTime"
+				],
+				"Text": [
+					"AuthorLogin",
+					"AuthorNickName",
+					"AuthorZoneIconUrl",
+					"AuthorZonePath",
+					"CollectionName",
+					"Comments",
+					"DecorationName",
+					"MapName",
+					"MapStyle",
+					"MapType",
+					"ObjectiveTextAuthor",
+					"ObjectiveTextBronze",
+					"ObjectiveTextGold",
+					"ObjectiveTextSilver"
+				]
+			},
+			"methods": []
+		},
+		"CMapEditorPlugin": {
+			"props": {
+				"Boolean": [
+					"BlockStockMode",
+					"EditorInputIsDown_Camera0",
+					"EditorInputIsDown_Camera1",
+					"EditorInputIsDown_Camera3",
+					"EditorInputIsDown_Camera7",
+					"EditorInputIsDown_Camera9",
+					"EditorInputIsDown_CameraDown",
+					"EditorInputIsDown_CameraLeft",
+					"EditorInputIsDown_CameraRight",
+					"EditorInputIsDown_CameraUp",
+					"EditorInputIsDown_CameraZoomNext",
+					"EditorInputIsDown_ClassicMapEditor",
+					"EditorInputIsDown_CursorDelete",
+					"EditorInputIsDown_CursorDown",
+					"EditorInputIsDown_CursorLeft",
+					"EditorInputIsDown_CursorLower",
+					"EditorInputIsDown_CursorPick",
+					"EditorInputIsDown_CursorPlace",
+					"EditorInputIsDown_CursorRaise",
+					"EditorInputIsDown_CursorRight",
+					"EditorInputIsDown_CursorTurn",
+					"EditorInputIsDown_CursorTurnSlightly",
+					"EditorInputIsDown_CursorTurnSlightlyAntiClockwise",
+					"EditorInputIsDown_CursorUp",
+					"EditorInputIsDown_IconDown",
+					"EditorInputIsDown_IconLeft",
+					"EditorInputIsDown_IconRight",
+					"EditorInputIsDown_IconUp",
+					"EditorInputIsDown_MapStyle",
+					"EditorInputIsDown_Menu",
+					"EditorInputIsDown_PivotChange",
+					"EditorInputIsDown_Redo",
+					"EditorInputIsDown_RemoveAll",
+					"EditorInputIsDown_Save",
+					"EditorInputIsDown_SaveAs",
+					"EditorInputIsDown_SwitchToRace",
+					"EditorInputIsDown_Undo",
+					"EnableAirMapping",
+					"EnableCursorShowingWhenInterfaceIsFocused",
+					"EnableEditorInputsCustomProcessing",
+					"EnableMixMapping",
+					"HideBlockHelpers",
+					"HideEditorInterface",
+					"HoldLoadingScreen",
+					"IsEditorReadyForRequest",
+					"IsUltraShadowsQualityAvailable",
+					"ShowPlacementGrid",
+					"UndergroundMode"
+				],
+				"CAnchorData[]": [
+					"AnchorData"
+				],
+				"CBlock[]": [
+					"Blocks"
+				],
+				"CBlockModel": [
+					"CursorBlockModel",
+					"CursorTerrainBlockModel"
+				],
+				"CBlockModel[]": [
+					"BlockModels",
+					"TerrainBlockModels"
+				],
+				"CItemAnchor[]": [
+					"Items"
+				],
+				"CMacroblockModel": [
+					"CursorMacroblockModel"
+				],
+				"CMacroblockModel[]": [
+					"MacroblockModels"
+				],
+				"CMap": [
+					"Map"
+				],
+				"CMapEditorPluginEvent[]": [
+					"PendingEvents"
+				],
+				"CMlPage": [
+					"ManialinkPage"
+				],
+				"CardinalDirections": [
+					"CursorDir"
+				],
+				"EditMode": [
+					"EditMode"
+				],
+				"Int3": [
+					"CursorCoord"
+				],
+				"Int3[]": [
+					"CustomSelectionCoords"
+				],
+				"Integer": [
+					"CollectionGroundY",
+					"MediatrackIngameEditedClipIndex"
+				],
+				"PlaceMode": [
+					"PlaceMode"
+				],
+				"Real": [
+					"CameraHAngle",
+					"CameraToTargetDistance",
+					"CameraVAngle",
+					"CollectionSquareHeight",
+					"CollectionSquareSize",
+					"CursorBrightnessFactor",
+					"ThumbnailCameraFovY",
+					"ThumbnailCameraHAngle",
+					"ThumbnailCameraRoll",
+					"ThumbnailCameraVAngle"
+				],
+				"ShadowsQuality": [
+					"CurrentShadowsQuality"
+				],
+				"Text": [
+					"ManialinkText",
+					"MapName"
+				],
+				"Text[]": [
+					"MediatrackIngameClips",
+					"MediatrackIngameIsScriptClips"
+				],
+				"ValidationStatus": [
+					"ValidationStatus"
+				],
+				"Vec3": [
+					"CameraPosition",
+					"CameraTargetPosition",
+					"CustomSelectionRGB",
+					"ThumbnailCameraPosition"
+				]
+			},
+			"methods": [
+				{
+					"name": "ComputeShadows",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ComputeShadows",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ShadowsQuality",
+							"argument": "ShadowsQuality"
+						}
+					]
+				},
+				{
+					"name": "DisplayDefaultSetObjectivesDialog",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Undo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Redo",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Help",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Validate",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "AutoSave",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Quit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "QuickQuit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "QuitAndSetResult",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "QuickQuitAndSetResult",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "TestMapFromStart",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "TestMapFromCoord",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "TestMapWithMode",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "RulesModeName"
+						}
+					]
+				},
+				{
+					"name": "SaveMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "SaveMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Path"
+						}
+					]
+				},
+				{
+					"name": "GetRaceCamera",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Yaw"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Pitch"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Roll"
+						},
+						{
+							"identifier": "Real",
+							"argument": "FovY"
+						}
+					]
+				},
+				{
+					"name": "RemoveAllBlocks",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveAllTerrain",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveAllOffZone",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveAllObjects",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveAllBlocksAndTerrain",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ShowCustomSelection",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "HideCustomSelection",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyPaste_Copy",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyPaste_Cut",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyPaste_Remove",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyPaste_SelectAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyPaste_ResetSelection",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "OpenToolsMenu",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "EditMediatrackIngame",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "PreloadAllBlocks",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "PreloadAllItems",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CanPlaceBlock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "OnGround"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "VariantIndex"
+						}
+					]
+				},
+				{
+					"name": "PlaceBlock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceBlock_NoDestruction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "OnGround"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "VariantIndex"
+						}
+					]
+				},
+				{
+					"name": "PlaceBlock_NoDestruction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceRoadBlocks",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "PlaceRoadBlocks",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceTerrainBlocks",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "PlaceTerrainBlocks",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "PlaceTerrainBlocks_NoDestruction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceMacroblock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "PlaceMacroblock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceMacroblock_NoDestruction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "PlaceMacroblock_NoDestruction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "CanPlaceMacroblock_NoTerrain",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "PlaceMacroblock_NoTerrain",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "RemoveMacroblock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "RemoveMacroblock_NoTerrain",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "GetBlock",
+					"returns": "CBlock",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						}
+					]
+				},
+				{
+					"name": "IsBlockModelSkinnable",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						}
+					]
+				},
+				{
+					"name": "GetNbBlockModelSkins",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						}
+					]
+				},
+				{
+					"name": "GetBlockModelSkin",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SkinIndex"
+						}
+					]
+				},
+				{
+					"name": "GetSkinDisplayName",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "SkinFileName"
+						}
+					]
+				},
+				{
+					"name": "GetBlockSkin",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CBlock",
+							"argument": "Block"
+						}
+					]
+				},
+				{
+					"name": "SetBlockSkin",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CBlock",
+							"argument": "Block"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SkinFileName"
+						}
+					]
+				},
+				{
+					"name": "OpenBlockSkinDialog",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CBlock",
+							"argument": "Block"
+						}
+					]
+				},
+				{
+					"name": "RemoveBlock",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "Coord"
+						}
+					]
+				},
+				{
+					"name": "RemoveTerrainBlocks",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "GetBlockGroundHeight",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CBlockModel",
+							"argument": "BlockModel"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "CoordX"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "CoordZ"
+						},
+						{
+							"identifier": "CardinalDirections",
+							"argument": "Dir"
+						}
+					]
+				},
+				{
+					"name": "GetGroundHeight",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "CoordX"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "CoordZ"
+						}
+					]
+				},
+				{
+					"name": "GetMouseCoordOnGround",
+					"returns": "Int3",
+					"params": []
+				},
+				{
+					"name": "GetMouseCoordAtHeight",
+					"returns": "Int3",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "CoordY"
+						}
+					]
+				},
+				{
+					"name": "GetStartLineBlock",
+					"returns": "CBlock",
+					"params": []
+				},
+				{
+					"name": "RemoveItem",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CAnchorData",
+							"argument": "Item"
+						}
+					]
+				},
+				{
+					"name": "CopyPaste_AddOrSubSelection",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Int3",
+							"argument": "StartCoord"
+						},
+						{
+							"identifier": "Int3",
+							"argument": "EndCoord"
+						}
+					]
+				},
+				{
+					"name": "CopyPaste_Symmetrize",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "SaveMacroblock",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMacroblockModel",
+							"argument": "MacroblockModel"
+						}
+					]
+				},
+				{
+					"name": "GetMacroblockModelFromFilePath",
+					"returns": "CMacroblockModel",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "MacroblockModelFilePath"
+						}
+					]
+				},
+				{
+					"name": "GetTerrainBlockModelFromName",
+					"returns": "CBlockModel",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "TerrainBlockModelName"
+						}
+					]
+				},
+				{
+					"name": "GetBlockModelFromName",
+					"returns": "CBlockModel",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "BlockModelName"
+						}
+					]
+				},
+				{
+					"name": "GetMapStyle",
+					"returns": "Text",
+					"params": []
+				},
+				{
+					"name": "SetMapStyle",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "MapStyle"
+						}
+					]
+				}
+			]
+		},
+		"CMapEditorPluginEvent": {
+			"props": {
+				"Boolean": [
+					"IsFromKeyboard",
+					"IsFromMouse",
+					"IsFromPad",
+					"OnlyScriptMetadataModified"
+				],
+				"EInput": [
+					"Input"
+				],
+				"Ident": [
+					"EditedAnchorDataId"
+				],
+				"Type": [
+					"Type"
+				]
+			},
+			"methods": []
+		},
+		"CMapEditorPluginLayer": {
+			"props": {
+				"CMapEditorPlugin": [
+					"Editor"
+				]
+			},
+			"methods": []
+		},
+		"CMapGroup": {
+			"props": {
+				"CMapInfo[]": [
+					"MapInfos"
+				]
+			},
+			"methods": [
+				{
+					"name": "IsUnlocked",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMapInfo": {
+			"props": {
+				"Boolean": [
+					"CreatedWithSimpleEditor",
+					"IsPlayable",
+					"TMObjective_IsLapRace",
+					"Unlocked"
+				],
+				"Integer": [
+					"CopperPrice",
+					"TMObjective_AuthorTime",
+					"TMObjective_BronzeTime",
+					"TMObjective_GoldTime",
+					"TMObjective_SilverTime"
+				],
+				"Text": [
+					"AuthorCountryFlagUrl",
+					"AuthorLogin",
+					"AuthorNickName",
+					"AuthorZoneFlagUrl",
+					"AuthorZonePath",
+					"CollectionName",
+					"Comments",
+					"FileName",
+					"MapStyle",
+					"MapType",
+					"MapUid",
+					"Name",
+					"Path"
+				]
+			},
+			"methods": []
+		},
+		"CMapType": {
+			"props": {
+				"Boolean": [
+					"CustomEditAnchorData",
+					"IsSwitchedToPlayground",
+					"ValidationEndNoConfirm",
+					"ValidationEndRequested"
+				],
+				"CUIConfigMgr": [
+					"UIManager"
+				],
+				"CUser[]": [
+					"Users"
+				],
+				"Text": [
+					"ValidabilityRequirementsMessage"
+				],
+				"ValidationStatus": [
+					"ValidationStatus"
+				]
+			},
+			"methods": [
+				{
+					"name": "ClearMapMetadata",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestEnterPlayground",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestLeavePlayground",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMatchSettings": {
+			"props": {
+				"CGameMatchSettingsPlaylistItemScript[]": [
+					"Playlist"
+				],
+				"Text": [
+					"FileName",
+					"Name",
+					"ScriptModeName"
+				]
+			},
+			"methods": [
+				{
+					"name": "ScriptModeName_Check",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ScriptModeName"
+						}
+					]
+				},
+				{
+					"name": "ScriptModeName_Set",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ScriptModeName"
+						}
+					]
+				},
+				{
+					"name": "Playlist_FileExists",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "File"
+						}
+					]
+				},
+				{
+					"name": "Playlist_FileMatchesMode",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "File"
+						}
+					]
+				},
+				{
+					"name": "Playlist_Add",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "File"
+						}
+					]
+				},
+				{
+					"name": "Playlist_Remove",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Index"
+						}
+					]
+				},
+				{
+					"name": "Playlist_SwapUp",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Index"
+						}
+					]
+				},
+				{
+					"name": "Playlist_SwapDown",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Index"
+						}
+					]
+				}
+			]
+		},
+		"CMatchSettingsManager": {
+			"props": {
+				"Boolean": [
+					"MatchSettings_EditScriptSettings_Ongoing"
+				],
+				"CMatchSettings[]": [
+					"MatchSettings"
+				]
+			},
+			"methods": [
+				{
+					"name": "MatchSettings_Refresh",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "MatchSettings_Create",
+					"returns": "CMatchSettings",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FilePath"
+						}
+					]
+				},
+				{
+					"name": "MatchSettings_Save",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						}
+					]
+				},
+				{
+					"name": "MatchSettings_SaveAs",
+					"returns": "CMatchSettings",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FilePath"
+						},
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						}
+					]
+				},
+				{
+					"name": "MatchSettings_EditScriptSettings",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						}
+					]
+				}
+			]
+		},
+		"CMlBrowser": {
+			"props": {
+				"Boolean": [
+					"IsInBrowser"
+				],
+				"CManiaAppBrowser": [
+					"ParentApp"
+				],
+				"CMap": [
+					"CurMap"
+				],
+				"EBuddyResult": [
+					"BuddyDoResult"
+				],
+				"Text": [
+					"BrowserFocusedFrameId",
+					"BuddyDoErrorMessage"
+				]
+			},
+			"methods": [
+				{
+					"name": "ShowCurMapCard",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserBack",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserQuit",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserHome",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "BrowserReload",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetLocalUserClubLink",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ClubLink"
+						}
+					]
+				}
+			]
+		},
+		"CMlCamera": {
+			"props": {},
+			"methods": []
+		},
+		"CMlControl": {
+			"props": {
+				"AlignHorizontal": [
+					"HorizontalAlign"
+				],
+				"AlignVertical": [
+					"VerticalAlign"
+				],
+				"Boolean": [
+					"IsFocused",
+					"Visible"
+				],
+				"CMlFrame": [
+					"Parent"
+				],
+				"Real": [
+					"AbsoluteRotation",
+					"AbsoluteScale",
+					"RelativeRotation",
+					"RelativeScale",
+					"ZIndex"
+				],
+				"Text": [
+					"ControlId",
+					"ToolTip"
+				],
+				"Text[]": [
+					"ControlClasses"
+				],
+				"Vec2": [
+					"AbsolutePosition_V3",
+					"RelativePosition_V3",
+					"Size"
+				]
+			},
+			"methods": [
+				{
+					"name": "HasClass",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Class"
+						}
+					]
+				},
+				{
+					"name": "DataAttributeExists",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "DataName"
+						}
+					]
+				},
+				{
+					"name": "DataAttributeGet",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "DataName"
+						}
+					]
+				},
+				{
+					"name": "DataAttributeSet",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "DataName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "DataValue"
+						}
+					]
+				},
+				{
+					"name": "Show",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Hide",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Unload",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Focus",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMlEntry": {
+			"props": {
+				"Boolean": [
+					"AutoNewLine"
+				],
+				"ETextFormat": [
+					"TextFormat"
+				],
+				"Integer": [
+					"MaxLine"
+				],
+				"Real": [
+					"Opacity",
+					"TextSizeReal"
+				],
+				"Text": [
+					"Value",
+					"TextColor"
+				]
+			},
+			"methods": [
+				{
+					"name": "StartEdition",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetText",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "NewText"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "SendSubmitEvent"
+						}
+					]
+				}
+			]
+		},
+		"CMlFileEntry": {
+			"props": {
+				"Text": [
+					"FullFileName"
+				]
+			},
+			"methods": []
+		},
+		"CMlFrame": {
+			"props": {
+				"Boolean": [
+					"ClipWindowActive",
+					"DisablePreload"
+				],
+				"CMlControl[]": [
+					"Controls"
+				],
+				"Vec2": [
+					"ClipWindowRelativePosition",
+					"ClipWindowSize"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetFirstChild",
+					"returns": "CMlControl",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ControlId"
+						}
+					]
+				}
+			]
+		},
+		"CMlGauge": {
+			"props": {
+				"Boolean": [
+					"CenteredBar",
+					"DrawBackground",
+					"DrawBlockBackground"
+				],
+				"Integer": [
+					"Clan"
+				],
+				"Real": [
+					"GradingRatio",
+					"Ratio"
+				],
+				"Text": [
+					"Style"
+				],
+				"Vec3": [
+					"Color"
+				]
+			},
+			"methods": [
+				{
+					"name": "SetRatio",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "NewRatio"
+						}
+					]
+				},
+				{
+					"name": "SetClan",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "NewClan"
+						}
+					]
+				}
+			]
+		},
+		"CMlGraph": {
+			"props": {
+				"CMlGraphCurve[]": [
+					"Curves"
+				],
+				"Vec2": [
+					"CoordsMax",
+					"CoordsMin"
+				]
+			},
+			"methods": [
+				{
+					"name": "AddCurve",
+					"returns": "CMlGraphCurve",
+					"params": []
+				},
+				{
+					"name": "RemoveCurve",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMlGraphCurve",
+							"argument": "Curve"
+						}
+					]
+				}
+			]
+		},
+		"CMlGraphCurve": {
+			"props": {
+				"Real": [
+					"Width"
+				],
+				"Text": [
+					"Style"
+				],
+				"Vec2[]": [
+					"Points"
+				],
+				"Vec3": [
+					"Color"
+				]
+			},
+			"methods": [
+				{
+					"name": "SortPoints",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMlLabel": {
+			"props": {
+				"Boolean": [
+					"AppendEllipsis",
+					"AutoNewLine"
+				],
+				"EBlendMode": [
+					"Blend"
+				],
+				"Integer": [
+					"MaxLine",
+					"ValueLineCount"
+				],
+				"Real": [
+					"LineSpacing",
+					"Opacity",
+					"TextSizeReal"
+				],
+				"Text": [
+					"Style",
+					"Substyle",
+					"TextFont",
+					"Value",
+					"TextColor"
+				]
+			},
+			"methods": [
+				{
+					"name": "SetText",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "NewText"
+						}
+					]
+				},
+				{
+					"name": "ComputeWidth",
+					"returns": "Real",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						}
+					]
+				},
+				{
+					"name": "ComputeWidth",
+					"returns": "Real",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Translated"
+						}
+					]
+				},
+				{
+					"name": "ComputeHeight",
+					"returns": "Real",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						}
+					]
+				}
+			]
+		},
+		"CMlMediaPlayer": {
+			"props": {
+				"Boolean": [
+					"IsInitPlay",
+					"IsLooping",
+					"Music"
+				],
+				"Real": [
+					"Volume"
+				],
+				"Text": [
+					"Url"
+				]
+			},
+			"methods": [
+				{
+					"name": "Play",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Stop",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "StopAndRewind",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMlMinimap": {
+			"props": {
+				"Boolean": [
+					"DisableAutoUnderground",
+					"Underground"
+				],
+				"Real": [
+					"MapYaw",
+					"ZoomFactor"
+				],
+				"Vec2": [
+					"MapPosition"
+				],
+				"Vec3": [
+					"WorldPosition"
+				]
+			},
+			"methods": [
+				{
+					"name": "Fog_SetAll",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Real",
+							"argument": "Value"
+						}
+					]
+				},
+				{
+					"name": "Fog_ClearDisk",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "WorldCenter"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Radius"
+						},
+						{
+							"identifier": "Real",
+							"argument": "FadeSize"
+						}
+					]
+				}
+			]
+		},
+		"CMlPage": {
+			"props": {
+				"Boolean": [
+					"LinksInhibited"
+				],
+				"CMlControl[]": [
+					"GetClassChildren_Result"
+				],
+				"CMlFrame": [
+					"MainFrame"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetFirstChild",
+					"returns": "CMlControl",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ControlId"
+						}
+					]
+				},
+				{
+					"name": "GetClassChildren",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Class"
+						},
+						{
+							"identifier": "CMlFrame",
+							"argument": "Frame"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Recursive"
+						}
+					]
+				}
+			]
+		},
+		"CMlQuad": {
+			"props": {
+				"Boolean": [
+					"DownloadInProgress",
+					"StyleSelected"
+				],
+				"CImage": [
+					"Image"
+				],
+				"EBlendMode": [
+					"Blend"
+				],
+				"EKeepRatioMode": [
+					"KeepRatio"
+				],
+				"Real": [
+					"Opacity"
+				],
+				"Text": [
+					"ImageUrl",
+					"ImageUrlFocus",
+					"Style",
+					"Substyle"
+				],
+				"Vec3": [
+					"BgColor",
+					"BgColorFocus",
+					"Colorize",
+					"ModulateColor"
+				]
+			},
+			"methods": [
+				{
+					"name": "ChangeImageUrl",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "fieldName"
+						}
+					]
+				}
+			]
+		},
+		"CMlScript": {
+			"props": {
+				"Boolean": [
+					"Dbg_WarnOnDroppedEvents",
+					"EnableMenuNavigationInputs",
+					"IsMenuNavigationForeground",
+					"KeyDelete",
+					"KeyDown",
+					"KeyLeft",
+					"KeyReturn",
+					"KeyRight",
+					"KeySpace",
+					"KeyUp",
+					"MouseLeftButton",
+					"MouseMiddleButton",
+					"MouseRightButton",
+					"PageIsVisible"
+				],
+				"CAnimManager": [
+					"AnimMgr"
+				],
+				"CAudioManager": [
+					"Audio"
+				],
+				"CDataFileMgr": [
+					"DataFileMgr"
+				],
+				"CHttpManager": [
+					"Http"
+				],
+				"CInputManager": [
+					"Input"
+				],
+				"CMlPage": [
+					"Page"
+				],
+				"CMlScriptEvent[]": [
+					"PendingEvents"
+				],
+				"CPresenceMgr": [
+					"PresenceMgr"
+				],
+				"CPrivilegeMgr": [
+					"PrivilegeMgr"
+				],
+				"CScoreMgr": [
+					"ScoreMgr"
+				],
+				"CTitle": [
+					"LoadedTitle"
+				],
+				"CUser": [
+					"LocalUser"
+				],
+				"CVideoManager": [
+					"Video"
+				],
+				"CXmlManager": [
+					"Xml"
+				],
+				"ESystemPlatform": [
+					"SystemPlatform"
+				],
+				"ESystemSkuIdentifier": [
+					"SystemSkuIdentifier"
+				],
+				"Integer": [
+					"CurrentTime",
+					"Now",
+					"Period"
+				],
+				"Real": [
+					"MouseX",
+					"MouseY"
+				],
+				"Text": [
+					"CurrentLocalDateText",
+					"CurrentTimeText",
+					"CurrentTimezone"
+				]
+			},
+			"methods": [
+				{
+					"name": "Dbg_SetProcessed",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMlScriptEvent",
+							"argument": "Event"
+						}
+					]
+				},
+				{
+					"name": "IsKeyPressed",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "KeyCode"
+						}
+					]
+				},
+				{
+					"name": "EnableMenuNavigation",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "EnableInputs"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "WithAutoFocus"
+						},
+						{
+							"identifier": "CMlControl",
+							"argument": "AutoBackControl"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "InputPriority"
+						}
+					]
+				},
+				{
+					"name": "OpenLink",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "LinkType",
+							"argument": "LinkType"
+						}
+					]
+				},
+				{
+					"name": "TriggerPageAction",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ActionString"
+						}
+					]
+				},
+				{
+					"name": "SendCustomEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "PreloadImage",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ImageUrl"
+						}
+					]
+				},
+				{
+					"name": "PreloadAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Dbg_DumpDeclareForVariables",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CNod",
+							"argument": "Nod"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "StatsOnly"
+						}
+					]
+				}
+			]
+		},
+		"CMlScriptEvent": {
+			"props": {
+				"Boolean": [
+					"IsActionAutoRepeat"
+				],
+				"CMlControl": [
+					"Control"
+				],
+				"EMenuNavAction": [
+					"MenuNavAction"
+				],
+				"Integer": [
+					"KeyCode"
+				],
+				"Text": [
+					"CharPressed",
+					"ControlId",
+					"CustomEventType",
+					"KeyName"
+				],
+				"Text[]": [
+					"CustomEventData"
+				],
+				"Type": [
+					"Type"
+				]
+			},
+			"methods": []
+		},
+		"CMlScriptIngame": {
+			"props": {
+				"Boolean": [
+					"IsInGameMenuDisplayed",
+					"IsSpectator",
+					"IsSpectatorClient",
+					"UseClans",
+					"UseForcedClans"
+				],
+				"CAchievementsManager": [
+					"AchievementsManager"
+				],
+				"CManiaAppPlaygroundCommon": [
+					"ParentApp"
+				],
+				"CMap": [
+					"Map"
+				],
+				"CPlaygroundClient": [
+					"Playground"
+				],
+				"CTeam[]": [
+					"Teams"
+				],
+				"CUIConfig": [
+					"ClientUI",
+					"UI"
+				],
+				"Integer": [
+					"GameTime"
+				],
+				"Text": [
+					"CurrentServerDesc",
+					"CurrentServerJoinLink",
+					"CurrentServerLogin",
+					"CurrentServerModeName",
+					"CurrentServerName"
+				]
+			},
+			"methods": [
+				{
+					"name": "ShowCurChallengeCard",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ShowModeHelp",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CopyServerLinkToClipBoard",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "JoinTeam1",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "JoinTeam2",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestSpectatorClient",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "Spectator"
+						}
+					]
+				},
+				{
+					"name": "SetSpectateTarget",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "ShowProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "ShowInGameMenu",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CloseInGameMenu",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EInGameMenuResult",
+							"argument": "Result"
+						}
+					]
+				},
+				{
+					"name": "CloseScoresTable",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "PlayUiSound",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EUISound",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SoundVariant"
+						},
+						{
+							"identifier": "Real",
+							"argument": "Volume"
+						}
+					]
+				}
+			]
+		},
+		"CMlStation": {
+			"props": {
+				"CManiaAppStation": [
+					"ParentApp"
+				],
+				"CStation": [
+					"Station"
+				]
+			},
+			"methods": [
+				{
+					"name": "EnterStation",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMlTextEdit": {
+			"props": {
+				"Boolean": [
+					"AutoNewLine",
+					"ShowLineNumbers"
+				],
+				"EControlScriptEditorTextFormat": [
+					"TextFormat"
+				],
+				"Integer": [
+					"MaxLine",
+					"ValueLineCount"
+				],
+				"Real": [
+					"LineSpacing",
+					"Opacity",
+					"TextSizeReal"
+				],
+				"Text": [
+					"Value",
+					"TextColor"
+				]
+			},
+			"methods": [
+				{
+					"name": "StartEdition",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CMode": {
+			"props": {
+				"Boolean": [
+					"Ladder_RequestInProgress",
+					"MapLoaded",
+					"MatchEndRequested",
+					"Replay_AutoStart",
+					"ServerShutdownRequested",
+					"Solo_NewRecordSequenceInProgress",
+					"UseMinimap"
+				],
+				"CAchievementsManager": [
+					"AchievementsManager"
+				],
+				"CDataFileMgr": [
+					"DataFileMgr"
+				],
+				"CHttpManager": [
+					"Http"
+				],
+				"CInputManager": [
+					"Input"
+				],
+				"CMap": [
+					"Map"
+				],
+				"CMapInfo[]": [
+					"MapList"
+				],
+				"CModeTurretManager": [
+					"TurretsManager"
+				],
+				"CModulePlaygroundHud": [
+					"Hud"
+				],
+				"CScoreMgr": [
+					"ScoreMgr"
+				],
+				"CServerAdmin": [
+					"ServerAdmin"
+				],
+				"CTeam[]": [
+					"Teams"
+				],
+				"CTitle": [
+					"LoadedTitle"
+				],
+				"CUIConfigMgr": [
+					"UIManager"
+				],
+				"CUser[]": [
+					"Users"
+				],
+				"CXmlManager": [
+					"Xml"
+				],
+				"CXmlRpc": [
+					"XmlRpc"
+				],
+				"ESystemPlatform": [
+					"SystemPlatform"
+				],
+				"Integer": [
+					"NextMapIndex",
+					"Now",
+					"Period"
+				],
+				"Text": [
+					"ClientManiaAppUrl",
+					"ForcedClubLinkUrl1",
+					"ForcedClubLinkUrl2",
+					"MapName",
+					"MapPlayerModelName",
+					"ModeStatusMessage",
+					"NeutralEmblemUrl",
+					"ServerLogin",
+					"ServerModeName",
+					"ServerName"
+				]
+			},
+			"methods": [
+				{
+					"name": "TweakTeamColorsToAvoidHueOverlap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestLoadMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestUnloadMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Hud_Load",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ModuleName"
+						}
+					]
+				},
+				{
+					"name": "PassOn",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUIConfigEvent",
+							"argument": "EventToPassOn"
+						}
+					]
+				},
+				{
+					"name": "Discard",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUIConfigEvent",
+							"argument": "EventToDiscard"
+						}
+					]
+				},
+				{
+					"name": "Ladder_OpenMatch_Request",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_AddPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "PlayerScore"
+						}
+					]
+				},
+				{
+					"name": "Ladder_OpenMatch_BeginRequest",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_OpenMatch_AddPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "PlayerScore"
+						}
+					]
+				},
+				{
+					"name": "Ladder_OpenMatch_EndRequest",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_CloseMatchRequest",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_CancelMatchRequest",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_SetResultsVersion",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Version"
+						}
+					]
+				},
+				{
+					"name": "Ladder_SetMatchMakingMatchId",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "MatchId"
+						}
+					]
+				},
+				{
+					"name": "Ladder_EnableChallengeMode",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "Enable"
+						}
+					]
+				},
+				{
+					"name": "AutoTeamBalance",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Solo_SetNewRecord",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "PlayerScore"
+						},
+						{
+							"identifier": "EMedal",
+							"argument": "PlayerScore"
+						}
+					]
+				},
+				{
+					"name": "Synchro_AddBarrier",
+					"returns": "Integer",
+					"params": []
+				},
+				{
+					"name": "Synchro_BarrierReached",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Barrier"
+						}
+					]
+				},
+				{
+					"name": "Users_AreAllies",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User1"
+						},
+						{
+							"identifier": "CUser",
+							"argument": "User2"
+						}
+					]
+				},
+				{
+					"name": "Users_RequestSwitchToSpectator",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						}
+					]
+				},
+				{
+					"name": "Users_CreateFake",
+					"returns": "CUser",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "NickName"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "RequestedTeam"
+						}
+					]
+				},
+				{
+					"name": "Users_DestroyFake",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						}
+					]
+				},
+				{
+					"name": "Users_SetNbFakeUsers",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "NbTeam1"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "NbTeam2"
+						}
+					]
+				},
+				{
+					"name": "Users_DestroyAllFakes",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ItemList_Begin",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ItemList_Begin",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "ItemList_Add",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ModelName"
+						}
+					]
+				},
+				{
+					"name": "ItemList_AddWithSkin",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ModelName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SkinNameOrUrl"
+						}
+					]
+				},
+				{
+					"name": "ItemList_End",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "DemoToken_StartUsingToken",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "DemoToken_StopUsingToken",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "DemoToken_GetAndUseToken",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						}
+					]
+				},
+				{
+					"name": "ActionList_Begin",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ActionList_Begin",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "ActionList_Add",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ActionName"
+						}
+					]
+				},
+				{
+					"name": "ActionList_End",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Replay_Start",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Replay_Stop",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Dbg_DumpDeclareForVariables",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CNod",
+							"argument": "Nod"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "StatsOnly"
+						}
+					]
+				}
+			]
+		},
+		"CModeTurret": {
+			"props": {
+				"CPlayer": [
+					"Owner"
+				],
+				"Integer": [
+					"Armor",
+					"ArmorMax"
+				]
+			},
+			"methods": []
+		},
+		"CModeTurretManager": {
+			"props": {
+				"CModeTurret[]": [
+					"Turrets"
+				]
+			},
+			"methods": [
+				{
+					"name": "MapTurrets_Reset",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Turret_Create",
+					"returns": "CModeTurret",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ModelId"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Direction"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Clan"
+						},
+						{
+							"identifier": "CPlayer",
+							"argument": "Owner"
+						}
+					]
+				},
+				{
+					"name": "Turret_Destroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CModeTurret",
+							"argument": "Turret"
+						}
+					]
+				},
+				{
+					"name": "Turret_DestroyAll",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CModuleMenu": {
+			"props": {},
+			"methods": [
+				{
+					"name": "Menu_Goto",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "PageId"
+						}
+					]
+				},
+				{
+					"name": "Menu_Back",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Previous",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Menu_Quit",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CModuleMenuComponent": {
+			"props": {
+				"CUILayer": [
+					"ComponentLayer"
+				]
+			},
+			"methods": [
+				{
+					"name": "Hide",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Show",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CModuleMenuFileBrowser": {
+			"props": {
+				"Boolean": [
+					"HasFinished"
+				],
+				"Text[]": [
+					"Selection"
+				]
+			},
+			"methods": [
+				{
+					"name": "SetFileType",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EFileType",
+							"argument": "FileType"
+						}
+					]
+				},
+				{
+					"name": "SetFileAction",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EFileAction",
+							"argument": "FileAction"
+						}
+					]
+				}
+			]
+		},
+		"CModuleMenuLayer": {
+			"props": {
+				"CModuleMenuComponent[]": [
+					"Components"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetFirstComponent",
+					"returns": "CModuleMenuComponent",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						}
+					]
+				}
+			]
+		},
+		"CModuleMenuModel": {
+			"props": {
+				"CModuleMenuPageModel[]": [
+					"Pages"
+				],
+				"Text": [
+					"MenuScript"
+				]
+			},
+			"methods": [
+				{
+					"name": "AddPage",
+					"returns": "CModuleMenuPageModel",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "PageUrl"
+						}
+					]
+				},
+				{
+					"name": "AddLink",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CModuleMenuPageModel",
+							"argument": "ParentPage"
+						},
+						{
+							"identifier": "CModuleMenuPageModel",
+							"argument": "ChildPage"
+						}
+					]
+				}
+			]
+		},
+		"CModuleMenuPageModel": {
+			"props": {
+				"Text": [
+					"ManialinkText"
+				]
+			},
+			"methods": []
+		},
+		"CModulePlayground": {
+			"props": {},
+			"methods": [
+				{
+					"name": "Hide",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Hide",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUIConfig",
+							"argument": "UIConfig"
+						}
+					]
+				},
+				{
+					"name": "Show",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Show",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUIConfig",
+							"argument": "UIConfig"
+						}
+					]
+				},
+				{
+					"name": "IsVisible",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUIConfig",
+							"argument": "UIConfig"
+						}
+					]
+				}
+			]
+		},
+		"CModulePlaygroundHud": {
+			"props": {
+				"CModulePlaygroundInventory": [
+					"Inventory"
+				],
+				"CModulePlaygroundScoresTable": [
+					"ScoresTable"
+				],
+				"CModulePlaygroundStore": [
+					"Store"
+				]
+			},
+			"methods": []
+		},
+		"CModulePlaygroundInventory": {
+			"props": {},
+			"methods": [
+				{
+					"name": "AddItem",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Quantity"
+						}
+					]
+				},
+				{
+					"name": "AddAction",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "RemoveInventoryItem",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Quantity"
+						}
+					]
+				},
+				{
+					"name": "GetInventoryItemQuantity",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "IsInventoryItemStored",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						}
+					]
+				},
+				{
+					"name": "[]",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "[]",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						}
+					]
+				}
+			]
+		},
+		"CModulePlaygroundScoresTable": {
+			"props": {},
+			"methods": [
+				{
+					"name": "SetFooterText",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FooterText"
+						}
+					]
+				},
+				{
+					"name": "ResetCustomColumns",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "Score"
+						}
+					]
+				},
+				{
+					"name": "ResetCustomColumns",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Scores_Sort",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EScoreSortOrder",
+							"argument": "SortOrder"
+						}
+					]
+				},
+				{
+					"name": "SetColumnValue",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "Score"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ColumnId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ColumnValue"
+						}
+					]
+				},
+				{
+					"name": "SetColumnValue",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "Score"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ColumnId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ColumnValue"
+						}
+					]
+				},
+				{
+					"name": "SetColumnValue",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CScore",
+							"argument": "Score"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ColumnId"
+						},
+						{
+							"identifier": "Real",
+							"argument": "ColumnValue"
+						}
+					]
+				},
+				{
+					"name": "SetColumnVisibility",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EColumnType",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Visibility"
+						}
+					]
+				},
+				{
+					"name": "SetColumnVisibility",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ColumnId"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Visibility"
+						}
+					]
+				}
+			]
+		},
+		"CModulePlaygroundStore": {
+			"props": {},
+			"methods": [
+				{
+					"name": "Reset",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Reset",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "SetMoney",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Amount"
+						}
+					]
+				},
+				{
+					"name": "GetMoney",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "AddMoney",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Amount"
+						}
+					]
+				},
+				{
+					"name": "SubMoney",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Amount"
+						}
+					]
+				},
+				{
+					"name": "SetActionLevel",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ActionUrl"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActionLevel"
+						}
+					]
+				},
+				{
+					"name": "GetActionLevel",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ActionUrl"
+						}
+					]
+				},
+				{
+					"name": "SetItemCanBeBought",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ActionUrl"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "CanBeBought"
+						}
+					]
+				},
+				{
+					"name": "GetItemCanBeBought",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ActionUrl"
+						}
+					]
+				}
+			]
+		},
+		"CNaturalLeaderBoardInfo": {
+			"props": {
+				"Ident": [
+					"UserId"
+				],
+				"Integer": [
+					"Rank",
+					"Score"
+				],
+				"Text": [
+					"DisplayName",
+					"FileName",
+					"Login",
+					"ReplayUrl"
+				]
+			},
+			"methods": []
+		},
+		"CNod": {
+			"props": {
+				"Ident": [
+					"Id"
+				]
+			},
+			"methods": []
+		},
+		"CNotificationsConsumer": {
+			"props": {
+				"CNotificationsConsumerEvent[]": [
+					"Events"
+				],
+				"CNotificationsConsumerNotification[]": [
+					"FilteredNotifications",
+					"Notifications"
+				],
+				"EFilterPriority": [
+					"Filter_Priority"
+				]
+			},
+			"methods": []
+		},
+		"CNotificationsConsumerEvent": {
+			"props": {
+				"CNotificationsConsumerNotification": [
+					"Notification"
+				],
+				"EType": [
+					"Type"
+				]
+			},
+			"methods": []
+		},
+		"CNotificationsConsumerNotification": {
+			"props": {
+				"Boolean": [
+					"HasBeenActivated",
+					"HasBeenRead"
+				],
+				"ENotificationPriority": [
+					"Priority"
+				],
+				"Text": [
+					"Description",
+					"ImageUrl",
+					"Title"
+				]
+			},
+			"methods": [
+				{
+					"name": "SetRead",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetActivated",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"COnlinePresence": {
+			"props": {
+				"Boolean": [
+					"IsOnline"
+				],
+				"Text": [
+					"DisplayName",
+					"Login",
+					"ServerLogin"
+				]
+			},
+			"methods": []
+		},
+		"CPackCreator": {
+			"props": {
+				"Boolean": [
+					"RegisterPack_IsInProgess"
+				],
+				"CPackCreatorPack": [
+					"CurrentPack"
+				]
+			},
+			"methods": [
+				{
+					"name": "RegisterPackForEditedTitle",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Build_Begin",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "CPackCreatorPack",
+							"argument": "Pack"
+						},
+						{
+							"identifier": "CPackCreatorTitleInfo",
+							"argument": "TitleInfo"
+						}
+					]
+				},
+				{
+					"name": "Build_AddFile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "Build_AddFolder",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "FolderName"
+						}
+					]
+				},
+				{
+					"name": "Build_AddFile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsPublic"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsInternal"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "NoAutomaticDeps"
+						}
+					]
+				},
+				{
+					"name": "Build_AddFolder",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "FolderName"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsPublic"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsInternal"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "NoRecursion"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "NoAutomaticDeps"
+						}
+					]
+				},
+				{
+					"name": "Build_Generate",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "Upload"
+						}
+					]
+				},
+				{
+					"name": "Build_IsGenerated",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						}
+					]
+				},
+				{
+					"name": "Build_ErrorMessage",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						}
+					]
+				},
+				{
+					"name": "Build_End",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "BuildId"
+						}
+					]
+				}
+			]
+		},
+		"CPackCreatorPack": {
+			"props": {
+				"Boolean": [
+					"IsTitlePack"
+				],
+				"CPackCreatorRecipient[]": [
+					"Recipients"
+				],
+				"Ident": [
+					"CreatorId",
+					"PackId"
+				]
+			},
+			"methods": [
+				{
+					"name": "Recipients_Add",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "UseCost"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "GetCost"
+						}
+					]
+				},
+				{
+					"name": "Recipients_Remove",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				}
+			]
+		},
+		"CPackCreatorRecipient": {
+			"props": {
+				"Integer": [
+					"GetCost",
+					"UseCost"
+				],
+				"Text": [
+					"Login"
+				]
+			},
+			"methods": []
+		},
+		"CPackCreatorTitleInfo": {
+			"props": {
+				"Boolean": [
+					"Solo_HasCampaign"
+				],
+				"Ident": [
+					"MakerTitleId",
+					"TitleId"
+				],
+				"Text": [
+					"AllowedClientTitleVersion",
+					"BaseTitleIds",
+					"Description",
+					"DisplayName",
+					"DownloadUrl",
+					"ForcedPlayerModel",
+					"Hud3dFontFileName",
+					"InfoUrl",
+					"Menus_BgReplayFileName",
+					"Menus_ManiaAppFileName",
+					"Menus_MusicFileName",
+					"MusicFolder",
+					"Packaging_Group",
+					"Packaging_ImageFileName",
+					"Packaging_LogosFileName",
+					"Station_ManialinkUrl",
+					"TitleVersion"
+				]
+			},
+			"methods": []
+		},
+		"CPlayer": {
+			"props": {
+				"Boolean": [
+					"RequestsSpectate"
+				],
+				"CUser": [
+					"User"
+				],
+				"Integer": [
+					"RequestedClan"
+				]
+			},
+			"methods": []
+		},
+		"CPlaygroundClient": {
+			"props": {
+				"Boolean": [
+					"DisablePlayingStateTracking",
+					"IsInGameMenuDisplayed",
+					"IsLoadingScreen",
+					"IsSpectator",
+					"IsSpectatorClient",
+					"UseClans",
+					"UseForcedClans"
+				],
+				"CMap": [
+					"Map"
+				],
+				"CServerInfo": [
+					"ServerInfo"
+				],
+				"CTeam[]": [
+					"Teams"
+				],
+				"CUIConfig": [
+					"UI"
+				],
+				"CUser": [
+					"LocalUser"
+				],
+				"Integer": [
+					"GameTime"
+				]
+			},
+			"methods": [
+				{
+					"name": "QuitServer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "Silent"
+						}
+					]
+				},
+				{
+					"name": "QuitServerAndSetResult",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "Silent"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "JoinTeam1",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "JoinTeam2",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RequestSpectatorClient",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "Spectator"
+						}
+					]
+				},
+				{
+					"name": "SetSpectateTarget",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "ShowProfile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Player"
+						}
+					]
+				}
+			]
+		},
+		"CPlug": {
+			"props": {},
+			"methods": []
+		},
+		"CPresenceMgr": {
+			"props": {
+				"CTaskResult[]": [
+					"TaskResults"
+				]
+			},
+			"methods": [
+				{
+					"name": "ReleaseTaskResult",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TaskId"
+						}
+					]
+				},
+				{
+					"name": "SetPresence",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "ERichPresence",
+							"argument": "UplayFlow"
+						}
+					]
+				},
+				{
+					"name": "GetOnlinePresenceForPlayers",
+					"returns": "CTaskResult_GetOnlinePresence",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				}
+			]
+		},
+		"CPrivilegeMgr": {
+			"props": {
+				"CTaskResult[]": [
+					"TaskResults"
+				]
+			},
+			"methods": [
+				{
+					"name": "ReleaseTaskResult",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TaskId"
+						}
+					]
+				},
+				{
+					"name": "CheckPrivilege",
+					"returns": "CTaskResult",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "EPrivilege",
+							"argument": "Privilege"
+						}
+					]
+				},
+				{
+					"name": "CheckPrivilegeForAllUsers",
+					"returns": "CTaskResult",
+					"params": [
+						{
+							"identifier": "EPrivilege",
+							"argument": "Privilege"
+						}
+					]
+				},
+				{
+					"name": "CheckTargetedPrivilege",
+					"returns": "CTaskResult_CheckTargetedPrivilege",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "EPrivilege",
+							"argument": "Privilege"
+						}
+					]
+				},
+				{
+					"name": "CheckTargetedPrivilegeForAllUsers",
+					"returns": "CTaskResult_CheckTargetedPrivilege",
+					"params": [
+						{
+							"identifier": "EPrivilege",
+							"argument": "Privilege"
+						}
+					]
+				}
+			]
+		},
+		"CRealLeaderBoardInfo": {
+			"props": {
+				"Ident": [
+					"UserId"
+				],
+				"Integer": [
+					"Rank"
+				],
+				"Real": [
+					"Score"
+				],
+				"Text": [
+					"DisplayName",
+					"FileName",
+					"Login",
+					"ReplayUrl"
+				]
+			},
+			"methods": []
+		},
+		"CReplayInfo": {
+			"props": {
+				"Text": [
+					"FileName",
+					"MapUid",
+					"Name",
+					"Path"
+				]
+			},
+			"methods": []
+		},
+		"CScore": {
+			"props": {
+				"Boolean": [
+					"IsRegisteredForLadderMatch"
+				],
+				"CUser": [
+					"User"
+				],
+				"Integer": [
+					"LadderClan",
+					"LadderRankSortValue"
+				],
+				"Real": [
+					"LadderMatchScoreValue",
+					"LadderScore"
+				]
+			},
+			"methods": []
+		},
+		"CScoreMgr": {
+			"props": {
+				"CTaskResult[]": [
+					"TaskResults"
+				]
+			},
+			"methods": [
+				{
+					"name": "TaskResult_Release",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TaskId"
+						}
+					]
+				},
+				{
+					"name": "ScoreStatus_GetLocalStatus",
+					"returns": "ELocalScoreStatus",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "ScoreStatus_GetMasterServerStatus",
+					"returns": "EMasterServerScoreStatus",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				},
+				{
+					"name": "Playground_GetPlayerGhost",
+					"returns": "CGhost",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "GamePlayer"
+						}
+					]
+				},
+				{
+					"name": "Map_SetNewRecord",
+					"returns": "CTaskResult",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "CGhost",
+							"argument": "Ghost"
+						}
+					]
+				},
+				{
+					"name": "Map_GetRecord",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						}
+					]
+				},
+				{
+					"name": "Map_GetRecordGhost",
+					"returns": "CTaskResult_Ghost",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						}
+					]
+				},
+				{
+					"name": "Map_GetMultiAsyncLevel",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						}
+					]
+				},
+				{
+					"name": "Map_GetMultiAsyncLevelRecord",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "MultiAsyncLevel"
+						}
+					]
+				},
+				{
+					"name": "Map_GetMultiAsyncLevelRecordGhost",
+					"returns": "CTaskResult_Ghost",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "MultiAsyncLevel"
+						}
+					]
+				},
+				{
+					"name": "Map_GetSkillPoints",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						}
+					]
+				},
+				{
+					"name": "MapLeaderBoard_GetPlayerRanking",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "MapLeaderBoard_GetPlayerCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "MapLeaderBoard_GetPlayerList",
+					"returns": "CTaskResult_NaturalLeaderBoardInfoList",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Context"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "FromIndex"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Count"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetMultiAsyncLevel",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetMultiAsyncLevelCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "MultiAsyncLevel"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetSkillPoints",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetOpponentRecords",
+					"returns": "CWebServicesTaskResult_MapRecordListScript",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "OpponentLogin"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetBuddiesMapRecord",
+					"returns": "CTaskResult_BuddiesChallengeRecord",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						}
+					]
+				},
+				{
+					"name": "Campaign_IsBuddiesMapRecordDirty",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapUid"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetBuddiesMapRecordsComparison",
+					"returns": "CTaskResult_BuddiesChallengeRecordsComparison",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						}
+					]
+				},
+				{
+					"name": "Campaign_GetBuddyMapRecordsComparison",
+					"returns": "CTaskResult_BuddyChallengeRecordsComparison",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "OpponentLogin"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						}
+					]
+				},
+				{
+					"name": "CampaignLeaderBoard_GetPlayerRanking",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseSkillPoints"
+						}
+					]
+				},
+				{
+					"name": "CampaignLeaderBoard_GetPlayerCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseSkillPoints"
+						}
+					]
+				},
+				{
+					"name": "CampaignLeaderBoard_GetPlayerList",
+					"returns": "CTaskResult_NaturalLeaderBoardInfoList",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "CampaignId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseSkillPoints"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "FromIndex"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Count"
+						}
+					]
+				},
+				{
+					"name": "Multiplayer_AddToScore",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Real",
+							"argument": "ScoreDiff"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Timestamp"
+						}
+					]
+				},
+				{
+					"name": "MultiplayerLeaderBoard_GetPlayerRanking",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "MultiplayerLeaderBoard_GetPlayerCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "GlobalLeaderBoard_GetPlayerRanking",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "GlobalLeaderBoard_GetPlayerCount",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						}
+					]
+				},
+				{
+					"name": "GlobalLeaderBoard_GetPlayerList",
+					"returns": "CTaskResult_RealLeaderBoardInfoList",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Zone"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "FromIndex"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Count"
+						}
+					]
+				}
+			]
+		},
+		"CServerAdmin": {
+			"props": {
+				"Boolean": [
+					"Authentication_GetTokenResponseReceived"
+				],
+				"CServerInfo": [
+					"ServerInfo"
+				],
+				"Integer": [
+					"Authentication_ErrorCode"
+				],
+				"Text": [
+					"Authentication_Token"
+				]
+			},
+			"methods": [
+				{
+					"name": "AutoTeamBalance",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Kick",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Reason"
+						}
+					]
+				},
+				{
+					"name": "Kick",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CClient",
+							"argument": "Client"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Reason"
+						}
+					]
+				},
+				{
+					"name": "Ban",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Reason"
+						}
+					]
+				},
+				{
+					"name": "Ban",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CClient",
+							"argument": "Client"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Reason"
+						}
+					]
+				},
+				{
+					"name": "ForceSpectator",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						},
+						{
+							"identifier": "ESpecMode",
+							"argument": "SpecMode"
+						}
+					]
+				},
+				{
+					"name": "ForceSpectator",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CClient",
+							"argument": "Client"
+						},
+						{
+							"identifier": "ESpecMode",
+							"argument": "SpecMode"
+						}
+					]
+				},
+				{
+					"name": "ForcePlayerRequestedTeam",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Team"
+						}
+					]
+				},
+				{
+					"name": "ForcePlayerRequestedTeam",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CClient",
+							"argument": "Client"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Team"
+						}
+					]
+				},
+				{
+					"name": "SetLobbyInfo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "IsLobby"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "LobbyPlayerCount"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "LobbyMaxPlayerCount"
+						},
+						{
+							"identifier": "Real",
+							"argument": "LobbyPlayersLevel"
+						}
+					]
+				},
+				{
+					"name": "SendToServerAfterMatch",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ServerUrl"
+						}
+					]
+				},
+				{
+					"name": "CustomizeQuitDialog",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ManialinkPage"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SendToServerUrl"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "ProposeAddToFavorites"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ForceDelay"
+						}
+					]
+				},
+				{
+					"name": "Authentication_GetToken",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						},
+						{
+							"identifier": "Text",
+							"argument": "AppLogin"
+						}
+					]
+				}
+			]
+		},
+		"CServerInfo": {
+			"props": {
+				"Boolean": [
+					"HasBuddies",
+					"IsFavourite",
+					"IsLobbyServer",
+					"IsPrivate",
+					"IsPrivateForSpectator"
+				],
+				"Integer": [
+					"MaxPlayerCount",
+					"MaxSpectatorCount",
+					"NbChallenges",
+					"PlayerCount",
+					"ServerLevel",
+					"SpectatorCount"
+				],
+				"Real": [
+					"LadderServerLimitMax",
+					"LadderServerLimitMin",
+					"PlayersLevelAvg",
+					"PlayersLevelMax",
+					"PlayersLevelMin"
+				],
+				"Text": [
+					"Comment",
+					"JoinLink",
+					"ModeName",
+					"SendToServerAfterMatchUrl",
+					"ServerLevelText",
+					"ServerLogin",
+					"ServerName",
+					"ServerVersionBuild"
+				],
+				"Text[]": [
+					"ChallengeNames",
+					"PlayerNames"
+				]
+			},
+			"methods": []
+		},
+		"CServerPlugin": {
+			"props": {
+				"Boolean": [
+					"MapLoaded"
+				],
+				"CClient[]": [
+					"Clients",
+					"Players",
+					"Spectators"
+				],
+				"CHttpManager": [
+					"Http"
+				],
+				"CMapInfo": [
+					"MapInfo"
+				],
+				"CMapInfo[]": [
+					"MapList"
+				],
+				"CScore[]": [
+					"Scores"
+				],
+				"CServerAdmin": [
+					"ServerAdmin"
+				],
+				"CServerPluginEvent[]": [
+					"PendingEvents"
+				],
+				"CTeam[]": [
+					"Teams"
+				],
+				"CTitle": [
+					"LoadedTitle"
+				],
+				"CUIConfigMgr": [
+					"UIManager"
+				],
+				"CUser[]": [
+					"Users"
+				],
+				"CXmlManager": [
+					"Xml"
+				],
+				"Integer": [
+					"CurMapIndex",
+					"NextMapIndex",
+					"Now"
+				],
+				"Text": [
+					"ForcedClubLinkUrl1",
+					"ForcedClubLinkUrl2",
+					"NeutralEmblemUrl"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetClient",
+					"returns": "CClient",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				},
+				{
+					"name": "TweakTeamColorsToAvoidHueOverlap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "TriggerModeScriptEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "RestartMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "NextMap",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Dbg_DumpDeclareForVariables",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CNod",
+							"argument": "Nod"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "StatsOnly"
+						}
+					]
+				}
+			]
+		},
+		"CServerPluginEvent": {
+			"props": {
+				"CClient": [
+					"Client"
+				],
+				"EType": [
+					"Type"
+				],
+				"Text": [
+					"ChatCommandType",
+					"ChatText",
+					"ModeCallbackType"
+				],
+				"Text[]": [
+					"ChatCommandData",
+					"ModeCallbackData"
+				]
+			},
+			"methods": []
+		},
+		"CSmAction": {
+			"props": {
+				"Boolean": [
+					"EnergyReload",
+					"HasNoPlayerCollision",
+					"IsActive",
+					"IsAttractor",
+					"IsBound",
+					"IsFlying",
+					"IsFreeLooking",
+					"IsFrozen",
+					"IsGliding",
+					"IsJumping",
+					"IsRunning",
+					"IsSliding",
+					"IsSneaking",
+					"State_Boolean1"
+				],
+				"CSmActionEvent[]": [
+					"PendingEvents"
+				],
+				"CSmPlayer": [
+					"Owner"
+				],
+				"CSmPlayer[]": [
+					"Players"
+				],
+				"Ident": [
+					"State_EntityId1"
+				],
+				"Integer": [
+					"Cooldown",
+					"Energy",
+					"EnergyCost",
+					"EnergyMax",
+					"Now",
+					"State_Integer1",
+					"Variant"
+				],
+				"Real": [
+					"AmmoGain"
+				]
+			},
+			"methods": [
+				{
+					"name": "SendRulesEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Param1"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Param2"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Victim"
+						}
+					]
+				},
+				{
+					"name": "SendRulesEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Param1"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Param2"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Victim"
+						},
+						{
+							"identifier": "CSmObject",
+							"argument": "Object"
+						}
+					]
+				},
+				{
+					"name": "SendRulesEvent",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Param1"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Param2"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Victim"
+						},
+						{
+							"identifier": "CSmObject",
+							"argument": "Object"
+						},
+						{
+							"identifier": "CModeTurret",
+							"argument": "Turret"
+						}
+					]
+				},
+				{
+					"name": "Anim_GetModelId",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ModelName"
+						}
+					]
+				},
+				{
+					"name": "Anim_PlayAtLocation",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "AnimModelId"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Direction"
+						}
+					]
+				},
+				{
+					"name": "Anim_PlayOnPlayer",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "AnimModelId"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "Anim_Stop",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "AnimId"
+						}
+					]
+				},
+				{
+					"name": "Projectile_GetModelId",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ModelName"
+						}
+					]
+				},
+				{
+					"name": "Projectile_CreateAtLocation",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ProjectileModelId"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "PlayerToIgnore"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "InitialPosition"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "InitialDirection"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "InitialVelocity"
+						}
+					]
+				},
+				{
+					"name": "Projectile_CreateOnPlayer",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ProjectileModelId"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						}
+					]
+				},
+				{
+					"name": "Cooldown_IsReady",
+					"returns": "Boolean",
+					"params": []
+				},
+				{
+					"name": "Cooldown_Start",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Shield_CreateAtLocation",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Direction"
+						}
+					]
+				},
+				{
+					"name": "Shield_CreateOnPlayer",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "ShieldOwner"
+						}
+					]
+				},
+				{
+					"name": "Shield_Destroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_Exists",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_GetArmor",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_SetArmor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ShieldArmor"
+						}
+					]
+				},
+				{
+					"name": "Shield_GetIsActive",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_SetIsActive",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "ShieldIsActive"
+						}
+					]
+				},
+				{
+					"name": "Shield_GetArmorMax",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_GetTickReload",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "Shield_GetCooldown",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ShieldId"
+						}
+					]
+				},
+				{
+					"name": "GetPlayerAmmo",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "GetPlayerAmmoMax",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				}
+			]
+		},
+		"CSmActionEvent": {
+			"props": {
+				"CModeTurret": [
+					"Turret"
+				],
+				"CSmObject": [
+					"Object"
+				],
+				"CSmPlayer": [
+					"Player"
+				],
+				"EType": [
+					"Type"
+				],
+				"Ident": [
+					"ProjectileModelId"
+				],
+				"Integer": [
+					"ContextId",
+					"Damage",
+					"Shield"
+				],
+				"Vec3": [
+					"Direction",
+					"Normal",
+					"Position"
+				]
+			},
+			"methods": []
+		},
+		"CSmBase": {
+			"props": {
+				"Boolean": [
+					"IsActive"
+				],
+				"Integer": [
+					"Clan",
+					"NumberOfCollectors"
+				]
+			},
+			"methods": []
+		},
+		"CSmBlock": {
+			"props": {
+				"CSmBase": [
+					"Base"
+				]
+			},
+			"methods": []
+		},
+		"CSmBlockPole": {
+			"props": {
+				"Boolean": [
+					"Captured"
+				],
+				"CSmGauge": [
+					"Gauge"
+				],
+				"CSmSector": [
+					"Sector"
+				]
+			},
+			"methods": []
+		},
+		"CSmGauge": {
+			"props": {
+				"Integer": [
+					"Clan",
+					"Max",
+					"Speed",
+					"Value"
+				],
+				"Real": [
+					"ValueReal"
+				]
+			},
+			"methods": []
+		},
+		"CSmLandmark": {
+			"props": {
+				"Integer": [
+					"Order"
+				],
+				"Text": [
+					"Tag"
+				],
+				"Vec3": [
+					"DirFront",
+					"Position"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapBase": {
+			"props": {
+				"Boolean": [
+					"IsActive"
+				],
+				"Integer": [
+					"Clan",
+					"NumberOfCollectors"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapBotPath": {
+			"props": {
+				"Boolean": [
+					"IsFlying"
+				],
+				"Integer": [
+					"Clan"
+				],
+				"Vec3[]": [
+					"Path"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapBotSpawn": {
+			"props": {
+				"Boolean": [
+					"IsFlying"
+				],
+				"Ident": [
+					"BotModelId"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapGate": {
+			"props": {
+				"Boolean": [
+					"AutoClosed",
+					"AutoIsActive",
+					"Automatic",
+					"ManualClosed"
+				],
+				"Integer": [
+					"AutoCloseDelay",
+					"AutoOpenSpeed",
+					"Clan"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapGauge": {
+			"props": {
+				"Boolean": [
+					"Captured"
+				],
+				"Integer": [
+					"Clan",
+					"Max",
+					"Speed",
+					"Value"
+				],
+				"Real": [
+					"ValueReal"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapLandmark": {
+			"props": {
+				"CSmMapBase": [
+					"Base"
+				],
+				"CSmMapBotPath": [
+					"BotPath"
+				],
+				"CSmMapBotSpawn": [
+					"BotSpawn"
+				],
+				"CSmMapGate": [
+					"Gate"
+				],
+				"CSmMapGauge": [
+					"Gauge"
+				],
+				"CSmMapObjectAnchor": [
+					"ObjectAnchor"
+				],
+				"CSmMapPlayerSpawn": [
+					"PlayerSpawn"
+				],
+				"CSmMapSector": [
+					"Sector"
+				],
+				"Integer": [
+					"Order"
+				],
+				"Text": [
+					"Tag"
+				],
+				"Vec3": [
+					"Position"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapObjectAnchor": {
+			"props": {
+				"Ident": [
+					"ItemModelId"
+				],
+				"Text": [
+					"ItemName"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapPlayerSpawn": {
+			"props": {},
+			"methods": []
+		},
+		"CSmMapSector": {
+			"props": {
+				"Ident[]": [
+					"PlayersIds"
+				],
+				"Text": [
+					"Tag"
+				]
+			},
+			"methods": []
+		},
+		"CSmMapType": {
+			"props": {
+				"CSmMode": [
+					"Mode"
+				],
+				"CSmPlayer[]": [
+					"AllPlayers",
+					"Players"
+				]
+			},
+			"methods": []
+		},
+		"CSmMlScriptIngame": {
+			"props": {
+				"Boolean": [
+					"HideResumePlayingButton"
+				],
+				"CSmMapBase[]": [
+					"MapBases"
+				],
+				"CSmMapLandmark[]": [
+					"MapLandmarks",
+					"MapLandmarks_BotPath",
+					"MapLandmarks_BotSpawn",
+					"MapLandmarks_Gate",
+					"MapLandmarks_Gauge",
+					"MapLandmarks_ObjectAnchor",
+					"MapLandmarks_PlayerSpawn",
+					"MapLandmarks_Sector"
+				],
+				"CSmPlayer": [
+					"GUIPlayer",
+					"InputPlayer"
+				],
+				"CSmPlayer[]": [
+					"Players"
+				],
+				"CSmScore[]": [
+					"Scores"
+				],
+				"Integer": [
+					"ArenaNow"
+				],
+				"Integer[]": [
+					"ClanScores"
+				]
+			},
+			"methods": []
+		},
+		"CSmMode": {
+			"props": {
+				"Boolean": [
+					"ForceNavMapsComputation",
+					"UseAllies",
+					"UseAmmoBonusOnHit",
+					"UseAutoDiscardBotEvents",
+					"UseAutoRespawnBots",
+					"UseAutoSpawnBots",
+					"UseBeaconsWithRecipients",
+					"UseClans",
+					"UseDefaultActionEvents",
+					"UseForcedClans",
+					"UseInterractiveScreensIn3d",
+					"UseLaserSkewering",
+					"UseLaserVsBullets",
+					"UsePlayerTagging",
+					"UseProtectClanmates",
+					"UsePvPCollisions",
+					"UsePvPWeapons",
+					"UseSameWallJump",
+					"WalkOnWall"
+				],
+				"CSmMapBase[]": [
+					"MapBases"
+				],
+				"CSmMapLandmark[]": [
+					"MapLandmarks",
+					"MapLandmarks_BotPath",
+					"MapLandmarks_BotSpawn",
+					"MapLandmarks_Gate",
+					"MapLandmarks_Gauge",
+					"MapLandmarks_ObjectAnchor",
+					"MapLandmarks_PlayerSpawn",
+					"MapLandmarks_Sector"
+				],
+				"CSmModeEvent[]": [
+					"PendingEvents"
+				],
+				"CSmObject[]": [
+					"Objects"
+				],
+				"CSmPlayer[]": [
+					"AllPlayers",
+					"BotPlayers",
+					"Players",
+					"Spectators"
+				],
+				"CSmScore[]": [
+					"Scores"
+				],
+				"EGameplay": [
+					"Gameplay"
+				],
+				"Ident": [
+					"OffZoneCenterLandmarkId"
+				],
+				"Integer": [
+					"ClansNbAlive",
+					"ClansNbDead",
+					"ClansNbTotal",
+					"EndTime",
+					"GameplayVersion",
+					"PlayersNbAlive",
+					"PlayersNbDead",
+					"PlayersNbTotal",
+					"SpawnInvulnerabilityDuration",
+					"StartTime"
+				],
+				"Integer[]": [
+					"ClanScores",
+					"ClansNbPlayers",
+					"ClansNbPlayersAlive"
+				],
+				"Real": [
+					"OffZoneRadius",
+					"OffZoneRadiusSpeed"
+				]
+			},
+			"methods": [
+				{
+					"name": "PassOn",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmModeEvent",
+							"argument": "Event"
+						}
+					]
+				},
+				{
+					"name": "Discard",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmModeEvent",
+							"argument": "Event"
+						}
+					]
+				},
+				{
+					"name": "SpawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Armor"
+						},
+						{
+							"identifier": "CSmMapPlayerSpawn",
+							"argument": "PlayerSpawn"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActivationDate"
+						}
+					]
+				},
+				{
+					"name": "SpawnBotPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Armor"
+						},
+						{
+							"identifier": "CSmMapPlayerSpawn",
+							"argument": "PlayerSpawn"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActivationDate"
+						}
+					]
+				},
+				{
+					"name": "SpawnBotPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Armor"
+						},
+						{
+							"identifier": "CSmMapBotPath",
+							"argument": "BotPath"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActivationDate"
+						}
+					]
+				},
+				{
+					"name": "SpawnBotPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Armor"
+						},
+						{
+							"identifier": "CSmMapBotSpawn",
+							"argument": "BotSpawn"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActivationDate"
+						}
+					]
+				},
+				{
+					"name": "SpawnBotPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Owner"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Armor"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Offset"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActivationDate"
+						}
+					]
+				},
+				{
+					"name": "UnspawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "ClearScores",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetPlayerClan",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						}
+					]
+				},
+				{
+					"name": "SetPlayerWeapon",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "DefaultWeapon"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "AutoSwitchWeapon"
+						}
+					]
+				},
+				{
+					"name": "SetPlayerReloadAllWeapons",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "ReloadAllWeapons"
+						}
+					]
+				},
+				{
+					"name": "SetPlayerAmmo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Count"
+						}
+					]
+				},
+				{
+					"name": "GetPlayerAmmo",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						}
+					]
+				},
+				{
+					"name": "AddPlayerAmmo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						},
+						{
+							"identifier": "Real",
+							"argument": "DeltaCount"
+						}
+					]
+				},
+				{
+					"name": "SetPlayerAmmoMax",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Count"
+						}
+					]
+				},
+				{
+					"name": "GetPlayerAmmoMax",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						}
+					]
+				},
+				{
+					"name": "AddPlayerArmor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Victim"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "DeltaArmor"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ShooterPoints"
+						}
+					]
+				},
+				{
+					"name": "RemovePlayerArmor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Victim"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "DeltaArmor"
+						},
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Shooter"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ShooterPoints"
+						}
+					]
+				},
+				{
+					"name": "GetWeaponNum",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "EWeapon",
+							"argument": "Weapon"
+						}
+					]
+				},
+				{
+					"name": "CanRespawnPlayer",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "RespawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "RespawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "CSmMapLandmark",
+							"argument": "CheckpointLandmark"
+						}
+					]
+				},
+				{
+					"name": "CreateBotPlayer",
+					"returns": "CSmPlayer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ModelId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "TeamNum"
+						}
+					]
+				},
+				{
+					"name": "DestroyBotPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						}
+					]
+				},
+				{
+					"name": "DestroyAllBotPlayers",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ScriptedBot_Move",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Goal"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_MoveDelta",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Delta"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_MoveAndAim",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Goal"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_MoveDeltaAndAim",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Delta"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_Aim",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Goal"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_AimDelta",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						},
+						{
+							"identifier": "Real",
+							"argument": "DeltaYaw"
+						},
+						{
+							"identifier": "Real",
+							"argument": "DeltaPitch"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_RequestAction",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						}
+					]
+				},
+				{
+					"name": "ScriptedBot_RequestGunTrigger",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "BotPlayer"
+						}
+					]
+				},
+				{
+					"name": "ActionLoad",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EActionSlot",
+							"argument": "ActionSlot"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ModelId"
+						}
+					]
+				},
+				{
+					"name": "ActionBind",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EActionSlot",
+							"argument": "ActionSlot"
+						},
+						{
+							"identifier": "EActionInput",
+							"argument": "ActionInput"
+						}
+					]
+				},
+				{
+					"name": "ActionSetVariant",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "EActionSlot",
+							"argument": "ActionSlot"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ActionVariant"
+						}
+					]
+				},
+				{
+					"name": "SetNbFakePlayers",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "NbClan1"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "NbClan2"
+						}
+					]
+				},
+				{
+					"name": "ObjectCreate",
+					"returns": "CSmObject",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "ModelId"
+						}
+					]
+				},
+				{
+					"name": "ObjectDestroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmObject",
+							"argument": "Object"
+						}
+					]
+				},
+				{
+					"name": "ObjectDestroyAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RemoveShieldArmor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "VictimShieldId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Damage"
+						}
+					]
+				},
+				{
+					"name": "Replay_SaveAttackScore",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Score"
+						}
+					]
+				},
+				{
+					"name": "Replay_SaveDefenseScore",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Score"
+						}
+					]
+				},
+				{
+					"name": "Replay_SaveTeamScore",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "Team"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Score"
+						}
+					]
+				},
+				{
+					"name": "Replay_SavePlayerOfInterest",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "Replay_SaveWinner",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "Replay_SaveInterface",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CSmModeEvent": {
+			"props": {
+				"Boolean": [
+					"CommandValueBoolean",
+					"GiveUp",
+					"PlayerWasInLadderMatch",
+					"PlayerWasSpawned",
+					"ShooterUsedAction",
+					"VictimUsedAction"
+				],
+				"CModeTurret": [
+					"ShooterTurret",
+					"VictimTurret"
+				],
+				"CSmBlockPole": [
+					"BlockPole"
+				],
+				"CSmMapLandmark": [
+					"Landmark"
+				],
+				"CSmMapSector": [
+					"Sector"
+				],
+				"CSmObject": [
+					"Object",
+					"VictimObject"
+				],
+				"CSmPlayer": [
+					"Player",
+					"Shooter",
+					"Victim"
+				],
+				"CUser": [
+					"User"
+				],
+				"EActionInput": [
+					"ActionInput"
+				],
+				"EActionSlot": [
+					"Action_Slot",
+					"ShooterActionSlot",
+					"VictimActionSlot"
+				],
+				"EType": [
+					"Type"
+				],
+				"Integer": [
+					"ActionChange",
+					"CommandValueInteger",
+					"Damage",
+					"ShooterClan",
+					"ShooterPoints",
+					"ShooterWeaponNum",
+					"VictimShield",
+					"VictimWeaponNum",
+					"WeaponNum"
+				],
+				"Real": [
+					"CommandValueReal",
+					"Height",
+					"MissDist"
+				],
+				"Text": [
+					"ActionId",
+					"CommandName",
+					"CommandValueText",
+					"Param1",
+					"ShooterActionId",
+					"VictimActionId"
+				],
+				"Text[]": [
+					"Param2"
+				],
+				"Vec3": [
+					"PlayerLastAimDirection",
+					"PlayerLastPosition"
+				]
+			},
+			"methods": []
+		},
+		"CSmObject": {
+			"props": {
+				"Boolean": [
+					"Throwable"
+				],
+				"CSmMapLandmark": [
+					"AnchorLandmark"
+				],
+				"CSmPlayer": [
+					"Player"
+				],
+				"EStatus": [
+					"Status"
+				],
+				"Ident": [
+					"ModelId"
+				],
+				"Integer": [
+					"MachineState"
+				],
+				"Vec3": [
+					"Position",
+					"Vel"
+				]
+			},
+			"methods": [
+				{
+					"name": "SetAnchor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmMapObjectAnchor",
+							"argument": "ObjectAnchor"
+						}
+					]
+				},
+				{
+					"name": "SetPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CSmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "SetPosition",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						}
+					]
+				},
+				{
+					"name": "SetPositionAndVel",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Vec3",
+							"argument": "Position"
+						},
+						{
+							"identifier": "Vec3",
+							"argument": "Vel"
+						}
+					]
+				},
+				{
+					"name": "SetUnspawned",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CSmPlayer": {
+			"props": {
+				"Boolean": [
+					"AllowProgressiveJump",
+					"AllowWallJump",
+					"AutoSwitchWeapon",
+					"HasShield",
+					"IsAttractorActivable",
+					"IsBot",
+					"IsCapturing",
+					"IsFakePlayer",
+					"IsHighlighted",
+					"IsInAir",
+					"IsInOffZone",
+					"IsInVehicle",
+					"IsInWater",
+					"IsOnTech",
+					"IsOnTechArmor",
+					"IsOnTechArrow",
+					"IsOnTechGround",
+					"IsOnTechLaser",
+					"IsOnTechNoWeapon",
+					"IsOnTechNucleus",
+					"IsOnTechSafeZone",
+					"IsOnTechTeleport",
+					"IsPowerJumpActivable",
+					"IsTeleportActivable",
+					"IsTouchingGround",
+					"IsUnderground",
+					"UseAlternateWeaponVisual"
+				],
+				"CSmMapLandmark": [
+					"CapturedLandmark"
+				],
+				"CSmObject[]": [
+					"Objects"
+				],
+				"CSmPlayerDriver": [
+					"Driver"
+				],
+				"CSmScore": [
+					"Score"
+				],
+				"ESpawnStatus": [
+					"SpawnStatus"
+				],
+				"Ident": [
+					"ForceModelId"
+				],
+				"Integer": [
+					"Armor",
+					"ArmorGain",
+					"ArmorMax",
+					"ArmorReplenishGain",
+					"CurAmmo",
+					"CurAmmoMax",
+					"CurAmmoUnit",
+					"CurWeapon",
+					"CurrentClan",
+					"EndTime",
+					"IdleDuration",
+					"NbActiveAttractors",
+					"Stamina",
+					"StartTime"
+				],
+				"Real": [
+					"AimPitch",
+					"AimYaw",
+					"AmmoGain",
+					"AmmoPower",
+					"ArmorPower",
+					"EnergyLevel",
+					"ForceLinearHue",
+					"GetLinearHue",
+					"JumpPower",
+					"Speed",
+					"SpeedPower",
+					"StaminaGain",
+					"StaminaMax",
+					"StaminaPower",
+					"ThrowSpeed"
+				],
+				"Vec3": [
+					"AimDirection",
+					"ForceColor",
+					"Position",
+					"Velocity"
+				]
+			},
+			"methods": []
+		},
+		"CSmPlayerDriver": {
+			"props": {
+				"Boolean": [
+					"IsFlying",
+					"IsStuck",
+					"RocketAnticipation",
+					"Scripted_ForceAimInMoveDir",
+					"UseOldShootingSystem"
+				],
+				"CSmPlayer": [
+					"ForcedTarget",
+					"Owner",
+					"Target"
+				],
+				"CSmPlayer[]": [
+					"TargetsToAvoid"
+				],
+				"ESmAttackFilter": [
+					"AttackFilter"
+				],
+				"ESmDriverBehaviour": [
+					"Behaviour"
+				],
+				"ESmDriverPatrolMode": [
+					"Patrol_Mode"
+				],
+				"Integer": [
+					"PathOffset",
+					"ReactionTime",
+					"Saunter_BaseChillingTime",
+					"Saunter_ChillingTimeDelta",
+					"ShootPeriodMax",
+					"ShootPeriodMin"
+				],
+				"Real": [
+					"Accuracy",
+					"AggroRadius",
+					"Agressivity",
+					"DisengageDistance",
+					"Escape_DistanceMaxEscape",
+					"Escape_DistanceMinEscape",
+					"Escape_DistanceSafe",
+					"Fov",
+					"PathSpeedCoef",
+					"Saunter_Radius",
+					"ShootRadius",
+					"TargetMinDistance"
+				],
+				"Vec3": [
+					"Escape_AnchorPoint",
+					"Saunter_AnchorPoint"
+				]
+			},
+			"methods": []
+		},
+		"CSmScore": {
+			"props": {
+				"Integer": [
+					"DamageInflicted",
+					"DamageTaken",
+					"NbEliminationsInflicted",
+					"NbEliminationsTaken",
+					"NbRespawnsRequested",
+					"Points",
+					"RoundPoints",
+					"TeamNum"
+				]
+			},
+			"methods": [
+				{
+					"name": "Clear",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CSmSector": {
+			"props": {
+				"Ident[]": [
+					"PlayersIds"
+				]
+			},
+			"methods": []
+		},
+		"CStation": {
+			"props": {
+				"Boolean": [
+					"DisableQuickEnter",
+					"IsEditable",
+					"IsLogoVisible"
+				],
+				"CTitle": [
+					"Title"
+				],
+				"EEchelon": [
+					"Echelon"
+				],
+				"Integer": [
+					"AudienceRegisteredUsers",
+					"CampaignMedalsCurrent",
+					"CampaignMedalsMax",
+					"CampaignMedalsRanking",
+					"LadderRank",
+					"NextEchelonPercent"
+				],
+				"Real": [
+					"GhostAlpha",
+					"LadderPoints"
+				],
+				"Vec3": [
+					"FocusLightColor",
+					"NormalLightColor"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult": {
+			"props": {
+				"Boolean": [
+					"HasFailed",
+					"HasSucceeded",
+					"IsCanceled",
+					"IsProcessing"
+				],
+				"ETaskErrorType": [
+					"ErrorType"
+				],
+				"Ident": [
+					"Id"
+				],
+				"Integer": [
+					"ErrorCode"
+				],
+				"Text": [
+					"ErrorDescription"
+				]
+			},
+			"methods": [
+				{
+					"name": "Cancel",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTaskResult_BuddiesChallengeRecord": {
+			"props": {
+				"CHighScoreComparison[]": [
+					"BuddiesChallengeRecord"
+				],
+				"Text": [
+					"Login"
+				]
+			},
+			"methods": [
+				{
+					"name": "SortByOpponentCount",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentDisplayName",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentLogin",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentRecordDate",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentRecordTime",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTaskResult_BuddiesChallengeRecordsComparison": {
+			"props": {
+				"CHighScoreComparisonSummary[]": [
+					"BuddiesComparison"
+				],
+				"Text": [
+					"Login"
+				]
+			},
+			"methods": [
+				{
+					"name": "SortByPlayerCount",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentLogin",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentCount",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentDate",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByOpponentDisplayName",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTaskResult_BuddyChallengeRecordsComparison": {
+			"props": {
+				"CHighScoreComparison[]": [
+					"BuddyBestRecordsComparison",
+					"PlayerBestRecordsComparison"
+				],
+				"Text": [
+					"BuddyLogin",
+					"Login"
+				]
+			},
+			"methods": [
+				{
+					"name": "SortByMapName",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByRecordTime",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByRecordTimeDiff",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SortByRecordDate",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTaskResult_CheckTargetedPrivilege": {
+			"props": {},
+			"methods": [
+				{
+					"name": "AddLogin",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				},
+				{
+					"name": "StartTask",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "HasPrivilege",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				},
+				{
+					"name": "GetDenyReason",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				}
+			]
+		},
+		"CTaskResult_FileList": {
+			"props": {
+				"Text": [
+					"ParentPath",
+					"Path"
+				],
+				"Text[]": [
+					"Files",
+					"SubFolders"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_GameModeList": {
+			"props": {
+				"CGameModeInfo[]": [
+					"GameModes"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_GetOnlinePresence": {
+			"props": {
+				"COnlinePresence[]": [
+					"OnlinePresences"
+				]
+			},
+			"methods": [
+				{
+					"name": "AddLogin",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Login"
+						}
+					]
+				},
+				{
+					"name": "StartTask",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTaskResult_Ghost": {
+			"props": {
+				"CGhost": [
+					"Ghost"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_GhostList": {
+			"props": {
+				"CGhost[]": [
+					"Ghosts"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_MapList": {
+			"props": {
+				"CMapInfo[]": [
+					"MapInfos"
+				],
+				"Text": [
+					"ParentPath",
+					"Path"
+				],
+				"Text[]": [
+					"SubFolders"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_NaturalLeaderBoardInfoList": {
+			"props": {
+				"CNaturalLeaderBoardInfo[]": [
+					"LeaderBoardInfo"
+				],
+				"Integer": [
+					"Count",
+					"FromIndex"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_RealLeaderBoardInfoList": {
+			"props": {
+				"CRealLeaderBoardInfo[]": [
+					"LeaderBoardInfo"
+				],
+				"Integer": [
+					"Count",
+					"FromIndex"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_ReplayList": {
+			"props": {
+				"CReplayInfo[]": [
+					"ReplayInfos"
+				],
+				"Text": [
+					"ParentPath",
+					"Path"
+				],
+				"Text[]": [
+					"SubFolders"
+				]
+			},
+			"methods": []
+		},
+		"CTaskResult_StringIntList": {
+			"props": {
+				"Text[]": [
+					"Values"
+				]
+			},
+			"methods": []
+		},
+		"CTeam": {
+			"props": {
+				"Text": [
+					"City",
+					"ClubLinkUrl",
+					"ColorText",
+					"ColorizedName",
+					"EmblemUrl",
+					"Name",
+					"PresentationManialinkUrl",
+					"ZonePath"
+				],
+				"Vec3": [
+					"ColorPrimary",
+					"ColorSecondary"
+				]
+			},
+			"methods": []
+		},
+		"CTitle": {
+			"props": {
+				"Text": [
+					"AuthorLogin",
+					"AuthorName",
+					"BaseTitleId",
+					"Desc",
+					"DownloadUrl",
+					"InfoUrl",
+					"MakerTitleId",
+					"Name",
+					"TitleId",
+					"TitleVersion"
+				]
+			},
+			"methods": []
+		},
+		"CTitleEdition": {
+			"props": {
+				"Boolean": [
+					"Dialog_Aborted",
+					"Dialog_IsFinished",
+					"Dialog_Success"
+				],
+				"CPackCreator": [
+					"PackCreator",
+					"EditedTitleInfo"
+				],
+				"CTitle": [
+					"TitleMaker"
+				],
+				"Text": [
+					"EditedTitleId"
+				]
+			},
+			"methods": [
+				{
+					"name": "File_ImportFromUser",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "File_Move",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "OrigName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "DestNameOrFolder"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "KeepOriginalCopy"
+						}
+					]
+				},
+				{
+					"name": "File_Exists",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						},
+						{
+							"identifier": "EDrive",
+							"argument": "InDrive"
+						}
+					]
+				},
+				{
+					"name": "File_Delete",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						}
+					]
+				},
+				{
+					"name": "File_WriteText",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						}
+					]
+				},
+				{
+					"name": "File_ReadText",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "Dialog_ImportFiles",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "OpenTitleFolderInExplorer",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "ReloadTitleDesc",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SaveTitleDesc",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SetTitleCampaign",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Integer",
+							"argument": "CampaignNum"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ScoreContext"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapsFolderNameOrPlayListName"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "OfficialRecordEnabled"
+						}
+					]
+				}
+			]
+		},
+		"CTitleFlow": {
+			"props": {
+				"Boolean": [
+					"CanPublishFiles",
+					"IsReady"
+				],
+				"CServerInfo": [
+					"GetServerInfo_Result"
+				],
+				"CServerInfo[]": [
+					"LocalServers",
+					"LocalServers_CurrentTitle"
+				],
+				"EResult": [
+					"LatestResult"
+				],
+				"Text": [
+					"CustomResultType"
+				],
+				"Text[]": [
+					"CustomResultData"
+				]
+			},
+			"methods": [
+				{
+					"name": "PlayMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Map"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlayCampaign",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CCampaign",
+							"argument": "Campaign"
+						},
+						{
+							"identifier": "CMapInfo",
+							"argument": "MapInfo"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlayMapList",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text[]",
+							"argument": "MapList"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlayMatchSettings",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						},
+						{
+							"identifier": "Text",
+							"argument": "OverrideMode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "OverrideSettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlaySplitScreen",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ESplitScreenLayout",
+							"argument": "LayoutType"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "MapList"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlayMultiOnSameScreen",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text[]",
+							"argument": "MapList"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Mode"
+						},
+						{
+							"identifier": "Text",
+							"argument": "SettingsXml"
+						}
+					]
+				},
+				{
+					"name": "PlaySplitScreen",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ESplitScreenLayout",
+							"argument": "LayoutType"
+						},
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						}
+					]
+				},
+				{
+					"name": "PlayMultiOnSameScreen",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						}
+					]
+				},
+				{
+					"name": "ViewReplay",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Replay"
+						}
+					]
+				},
+				{
+					"name": "OpenEditor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "EditorName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MainPluginSettings"
+						}
+					]
+				},
+				{
+					"name": "OpenEditor",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "EEditorType",
+							"argument": "EditorType"
+						}
+					]
+				},
+				{
+					"name": "EditSkins",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "EditReplay",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text[]",
+							"argument": "ReplayList"
+						}
+					]
+				},
+				{
+					"name": "EditGhosts",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Map"
+						}
+					]
+				},
+				{
+					"name": "EditAsset",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "EditorName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MainPluginSettingsXml"
+						},
+						{
+							"identifier": "Text",
+							"argument": "RelativeFileName"
+						}
+					]
+				},
+				{
+					"name": "EditMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Map"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginScript"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginArgument"
+						}
+					]
+				},
+				{
+					"name": "EditNewMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Environment"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Decoration"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ModNameOrUrl"
+						},
+						{
+							"identifier": "Text",
+							"argument": "PlayerModel"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapType"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginScript"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginArgument"
+						}
+					]
+				},
+				{
+					"name": "EditNewMap",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Environment"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Decoration"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ModNameOrUrl"
+						},
+						{
+							"identifier": "Text",
+							"argument": "PlayerModel"
+						},
+						{
+							"identifier": "Text",
+							"argument": "MapType"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "UseSimpleEditor"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginScript"
+						},
+						{
+							"identifier": "Text",
+							"argument": "EditorPluginArgument"
+						}
+					]
+				},
+				{
+					"name": "EditBadges",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "PublishFile",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "FileName"
+						}
+					]
+				},
+				{
+					"name": "DiscoverLocalServers",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "CreateServer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ServerName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ServerComment"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "MaxPlayerCount"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Password"
+						},
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						},
+						{
+							"identifier": "Text",
+							"argument": "PasswordSpectators"
+						}
+					]
+				},
+				{
+					"name": "CreateServer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ServerName"
+						},
+						{
+							"identifier": "Text",
+							"argument": "ServerComment"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "MaxPlayerCount"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Password"
+						},
+						{
+							"identifier": "Text",
+							"argument": "PasswordSpectators"
+						},
+						{
+							"identifier": "CMatchSettings",
+							"argument": "MatchSettings"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "LocalOnly"
+						}
+					]
+				},
+				{
+					"name": "GetServerInfo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ServerLogin"
+						}
+					]
+				},
+				{
+					"name": "GetServerInfo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CServerInfo",
+							"argument": "LocalServer"
+						}
+					]
+				},
+				{
+					"name": "GetServerInfo_Abort",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Join_GetServerInfo_Result",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Boolean",
+							"argument": "AsSpectator"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Password"
+						}
+					]
+				},
+				{
+					"name": "JoinServer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "ServerLogin"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "AsSpectator"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Password"
+						}
+					]
+				},
+				{
+					"name": "Quit",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTmMapType": {
+			"props": {
+				"CTmMode": [
+					"Mode"
+				],
+				"CTmPlayer[]": [
+					"AllPlayers",
+					"Players"
+				]
+			},
+			"methods": [
+				{
+					"name": "TMObjective_SetFromBestRace",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CTmScore",
+							"argument": "Score"
+						}
+					]
+				}
+			]
+		},
+		"CTmMlPlayer": {
+			"props": {
+				"Boolean": [
+					"BonusIsPossible",
+					"BonusModeEventIsGold",
+					"BonusModeIsBigCar",
+					"BonusModeIsEmptyCars",
+					"BonusModeIsGold",
+					"BonusModeIsJump",
+					"BonusModeIsMiniCar",
+					"BonusModeIsSpeedyCars",
+					"BonusModeIsTurbo",
+					"ButtonSmashFrenzy",
+					"EnableCatchUpSpeed",
+					"EnableEmptyCars",
+					"EnableOnlineMode",
+					"EnableStuntMode",
+					"EnableTurboButton",
+					"ForcedAerialCamera",
+					"InputIsBraking",
+					"IsDeadlyZoneActive",
+					"IsSpawned",
+					"MaxiAirControl",
+					"SmashNeedHelp",
+					"StuntCurComboChainCounter",
+					"StuntCurFigureMasterJump",
+					"StuntEpicLanding",
+					"StuntIsInFigure",
+					"StuntMasterJump",
+					"StuntMasterLanding",
+					"StuntPerfectLanding",
+					"StuntReverseLanding",
+					"StuntStraightLanding",
+					"TinyCar"
+				],
+				"CTmResult": [
+					"CurLap",
+					"CurRace"
+				],
+				"CTrackManiaScore": [
+					"Score"
+				],
+				"ERaceState": [
+					"RaceState"
+				],
+				"ESceneVehiclePhyStuntFigure": [
+					"StuntLast"
+				],
+				"ETmBonusModeEventType": [
+					"BonusModeEventType"
+				],
+				"ETmJumpMode": [
+					"JumpMode"
+				],
+				"ETmRacePlayerCoopMode": [
+					"CoopMode"
+				],
+				"Integer": [
+					"BonusBumpCooldown",
+					"BonusModeEmptyCarsStock",
+					"BonusModeJumpStock",
+					"BonusModeTimeTillEndEvent",
+					"BonusModeTimeTillEvent",
+					"BonusModeTimeTillEventWarning",
+					"BonusModeTurboStock",
+					"ControllerCount",
+					"ControllerId0",
+					"ControllerId1",
+					"ControllerId2",
+					"ControllerId3",
+					"CoopCheckpointCurController",
+					"CoopSymbiosysPercentTotal",
+					"CurCheckpointLapTime",
+					"CurCheckpointRaceTime",
+					"CurRaceContinuousRank",
+					"CurTriggerIndex",
+					"CurrentClan",
+					"CurrentNbLaps",
+					"DisplaySpeed",
+					"EngineCurGear",
+					"FlyingDuration",
+					"FreeWheelingDuration",
+					"InWaterDuration",
+					"LapStartTime",
+					"LightTrailsDuration",
+					"RaceStartTime",
+					"SkiddingDuration",
+					"SparklingDuration",
+					"StuntAngle",
+					"StuntCombo",
+					"StuntLastTime",
+					"StuntPoints",
+					"TimeBeforeDeadlyZone",
+					"TimeElapsedSinceLastStunt",
+					"TimeLeftForStuntCombo",
+					"TimeTillSmashGiveUp",
+					"TimeTillSmashRespawn",
+					"UniqueCameraAvailableRespawnLeft",
+					"UniqueCameraRespawnCount",
+					"WheelsContactCount",
+					"WheelsSkiddingCount"
+				],
+				"Real": [
+					"AccelCoef",
+					"AimPitch",
+					"AimYaw",
+					"ControlCoef",
+					"DamageHullRatio",
+					"DamageWindowRatio",
+					"Distance",
+					"EngineRpm",
+					"EngineTurboRatio",
+					"FlyingDistance",
+					"GravityCoef",
+					"InputGasPedal",
+					"InputSteer",
+					"SkiddingDistance",
+					"Speed",
+					"StuntCurFigureEpicGauge",
+					"StuntCurFigureMasterGauge",
+					"StuntFactor",
+					"Upwardness"
+				],
+				"Vec3": [
+					"AimDirection",
+					"Position"
+				]
+			},
+			"methods": []
+		},
+		"CTmMlScriptIngame": {
+			"props": {
+				"Boolean": [
+					"IndependantLaps",
+					"MapIsLapRace"
+				],
+				"CTmMlPlayer": [
+					"GUIPlayer",
+					"InputPlayer"
+				],
+				"CTmMlPlayer[]": [
+					"Players"
+				],
+				"CTmRaceClientEvent[]": [
+					"RaceEvents"
+				],
+				"CTmScore[]": [
+					"Scores"
+				],
+				"Integer": [
+					"CurPlayerCamera",
+					"MapNbLaps",
+					"NbLaps",
+					"SplitScreenCount",
+					"SplitScreenNum"
+				],
+				"Integer[]": [
+					"ClanScores"
+				],
+				"Vec3": [
+					"MapStartLinePos"
+				],
+				"Vec3[]": [
+					"MapCheckpointPos",
+					"MapFinishLinePos"
+				]
+			},
+			"methods": []
+		},
+		"CTmMode": {
+			"props": {
+				"Boolean": [
+					"EnableBonusEvents",
+					"EnableCheckpointBonus",
+					"EnableCollisions",
+					"EnableLegacyXmlRpcCallbacks",
+					"EnableScaleCar",
+					"EnableUniqueCamera",
+					"HideOpponents",
+					"IndependantLaps",
+					"MapIsLapRace",
+					"MedalGhost_ShowBronze",
+					"MedalGhost_ShowGold",
+					"MedalGhost_ShowSilver",
+					"StuntModel_EnableCustomisation",
+					"StuntModel_MP3Combo",
+					"StuntModel_MP3Points",
+					"StuntModel_UseStricterAngle",
+					"UiDisableHelpMessage",
+					"UiDisplayStuntsNames",
+					"UiLaps",
+					"UiRounds",
+					"UiStuntsMode",
+					"UseClans",
+					"UseForcedClans"
+				],
+				"CTmModeEvent[]": [
+					"PendingEvents"
+				],
+				"CTmPlayer[]": [
+					"AllPlayers",
+					"Players",
+					"PlayersRacing",
+					"PlayersWaiting",
+					"Spectators"
+				],
+				"CTmScore[]": [
+					"Scores"
+				],
+				"EPersonalGhost": [
+					"PersonalGhost"
+				],
+				"ETMRespawnBehaviour": [
+					"RespawnBehaviour"
+				],
+				"ETmRaceChronoBehaviour": [
+					"UiRaceChrono"
+				],
+				"Integer": [
+					"Clan1Score",
+					"Clan2Score",
+					"ClansNbTotal",
+					"CutOffTimeLimit",
+					"ForceMaxOpponents",
+					"MapNbLaps",
+					"NbLaps",
+					"StuntModel_InterComboDelay",
+					"StuntModel_InterComboDelayExtendPerPoint",
+					"StuntModel_MinStuntDuration",
+					"StuntModel_RespawnPenalty",
+					"UiScoresPointsLimit"
+				],
+				"Integer[]": [
+					"ClanScores",
+					"ClansNbPlayers"
+				],
+				"Real": [
+					"StuntModel_FigureRepeatMalus"
+				],
+				"Vec3": [
+					"MapStartLinePos"
+				],
+				"Vec3[]": [
+					"MapCheckpointPos",
+					"MapFinishLinePos"
+				]
+			},
+			"methods": [
+				{
+					"name": "PassOn",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "CTmModeEvent",
+							"argument": "Event"
+						}
+					]
+				},
+				{
+					"name": "Discard",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CTmModeEvent",
+							"argument": "Event"
+						}
+					]
+				},
+				{
+					"name": "SpawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CTmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "RaceStartTime"
+						}
+					]
+				},
+				{
+					"name": "UnspawnPlayer",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CTmPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "SetPlayerClan",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CTmPlayer",
+							"argument": "Player"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "ClanNum"
+						}
+					]
+				},
+				{
+					"name": "Scores_Sort",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ETmScoreSortOrder",
+							"argument": "SortOrder"
+						}
+					]
+				},
+				{
+					"name": "Scores_Clear",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Ladder_ComputeRank",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "ETmScoreSortOrder",
+							"argument": "SortOrder"
+						}
+					]
+				},
+				{
+					"name": "Cheats_Reset",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RaceGhost_Add",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "CGhost",
+							"argument": "Ghost"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "DisplayAsPlayerBest"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_AddWithOffset",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "CGhost",
+							"argument": "Ghost"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "OffsetMs"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_Add",
+					"returns": "Ident",
+					"params": [
+						{
+							"identifier": "CGhost",
+							"argument": "Ghost"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "DisplayAsPlayerBest"
+						},
+						{
+							"identifier": "Ident",
+							"argument": "ModelId"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_Remove",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostInstId"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_RemoveAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "RaceGhost_GetStartTime",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostInstId"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_GetCurCheckpoint",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostInstId"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_GetCheckpointTime",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostInstId"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "Checkpoint"
+						}
+					]
+				},
+				{
+					"name": "RaceGhost_IsReplayOver",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "GhostInstId"
+						}
+					]
+				}
+			]
+		},
+		"CTmModeEvent": {
+			"props": {
+				"Boolean": [
+					"CommandValueBoolean",
+					"IsEndLap",
+					"IsEndRace",
+					"IsEpicLanding",
+					"IsMasterJump",
+					"IsMasterLanding",
+					"IsPerfectLanding",
+					"IsReverse",
+					"IsStraight",
+					"PlayerWasInLadderMatch",
+					"PlayerWasSpawned"
+				],
+				"CTmPlayer": [
+					"Player"
+				],
+				"CUser": [
+					"User"
+				],
+				"EStuntFigure": [
+					"StuntFigure"
+				],
+				"EType": [
+					"Type"
+				],
+				"Ident": [
+					"BlockId"
+				],
+				"Integer": [
+					"Angle",
+					"CheckpointInLap",
+					"CheckpointInRace",
+					"Combo",
+					"CommandValueInteger",
+					"LapTime",
+					"NbRespawns",
+					"Points",
+					"RaceTime",
+					"StuntsScore"
+				],
+				"Real": [
+					"CommandValueReal",
+					"Damages",
+					"Distance",
+					"Factor",
+					"Speed"
+				],
+				"Text": [
+					"CommandName",
+					"CommandValueText"
+				]
+			},
+			"methods": []
+		},
+		"CTmPlayer": {
+			"props": {
+				"Boolean": [
+					"IsSpawned"
+				],
+				"CTmResult": [
+					"CurLap",
+					"CurRace"
+				],
+				"CTmScore": [
+					"Score"
+				],
+				"Ident": [
+					"ForceModelId"
+				],
+				"Integer": [
+					"CurTriggerIndex",
+					"CurrentClan",
+					"CurrentNbLaps",
+					"IdleDuration",
+					"RaceStartTime"
+				],
+				"Real": [
+					"AccelCoef",
+					"AimPitch",
+					"AimYaw",
+					"ControlCoef",
+					"GravityCoef",
+					"Speed"
+				],
+				"Vec3": [
+					"AimDirection",
+					"Position",
+					"Velocity"
+				]
+			},
+			"methods": []
+		},
+		"CTmRaceClientEvent": {
+			"props": {
+				"Boolean": [
+					"IsEndLap",
+					"IsEndRace"
+				],
+				"CTmMlPlayer": [
+					"Player"
+				],
+				"EType": [
+					"Type"
+				],
+				"Integer": [
+					"CheckpointInLap",
+					"CheckpointInRace",
+					"LapTime",
+					"NbRespawns",
+					"RaceTime",
+					"StuntsScore"
+				]
+			},
+			"methods": []
+		},
+		"CTmResult": {
+			"props": {
+				"Integer": [
+					"NbRespawns",
+					"Score",
+					"Time"
+				],
+				"Integer[]": [
+					"Checkpoints"
+				]
+			},
+			"methods": [
+				{
+					"name": "Compare",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "CTmResult",
+							"argument": "Other"
+						},
+						{
+							"identifier": "ETmRaceResultCriteria",
+							"argument": "Criteria"
+						}
+					]
+				}
+			]
+		},
+		"CTmScore": {
+			"props": {
+				"CTmResult": [
+					"BestLap",
+					"BestRace",
+					"PrevRace",
+					"TempResult"
+				],
+				"Integer": [
+					"Points",
+					"PrevRaceDeltaPoints",
+					"TeamNum"
+				]
+			},
+			"methods": [
+				{
+					"name": "Clear",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CTrackManiaScore": {
+			"props": {},
+			"methods": []
+		},
+		"CUIConfig": {
+			"props": {
+				"Boolean": [
+					"AltMenuNoCustomScores",
+					"AltMenuNoDefaultScores",
+					"ForceSpectator",
+					"NoticesFilter_HideMapInfo",
+					"NoticesFilter_HideMapWarning",
+					"NoticesFilter_HideMatchInfo",
+					"NoticesFilter_HideMatchWarning",
+					"NoticesFilter_HidePlayerInfo",
+					"NoticesFilter_HidePlayerInfoIfNotMe",
+					"NoticesFilter_HidePlayerWarning",
+					"NoticesFilter_HidePlayerWarningIfNotMe",
+					"OverlayChatHideAvatar",
+					"OverlayHide321Go",
+					"OverlayHideBackground",
+					"OverlayHideChat",
+					"OverlayHideCheckPointList",
+					"OverlayHideCheckPointTime",
+					"OverlayHideChrono",
+					"OverlayHideConsumables",
+					"OverlayHideCountdown",
+					"OverlayHideCrosshair",
+					"OverlayHideEndMapLadderRecap",
+					"OverlayHideGauges",
+					"OverlayHideMapInfo",
+					"OverlayHideMultilapInfos",
+					"OverlayHideNotices",
+					"OverlayHideOpponentsInfo",
+					"OverlayHidePersonnalBestAndRank",
+					"OverlayHidePosition",
+					"OverlayHideRoundScores",
+					"OverlayHideSpectatorControllers",
+					"OverlayHideSpectatorInfos",
+					"OverlayHideSpeedAndDist",
+					"OverlayScoreSummary",
+					"ScoreTableOnlyManialink",
+					"ScreenIn3dHideScoreSummary",
+					"ScreenIn3dHideVersus",
+					"UISequenceIsCompleted",
+					"UISequence_CanSkipIntroMT"
+				],
+				"CUILayer[]": [
+					"UILayers"
+				],
+				"EAvatarVariant": [
+					"BigMessageAvatarVariant"
+				],
+				"EHudVisibility": [
+					"LabelsVisibility"
+				],
+				"ELabelsVisibility": [
+					"AlliesLabelsVisibility",
+					"OpposingTeamLabelsVisibility",
+					"TeamLabelsVisibility"
+				],
+				"ENoticeLevel": [
+					"NoticesFilter_LevelToShowAsBigMessage"
+				],
+				"EObserverMode": [
+					"SpectatorObserverMode"
+				],
+				"EUISequence": [
+					"UISequence"
+				],
+				"EUISound": [
+					"BigMessageSound"
+				],
+				"EUIStatus": [
+					"UIStatus"
+				],
+				"EVisibility": [
+					"AlliesLabelsShowGauges",
+					"AlliesLabelsShowNames",
+					"OpposingTeamLabelsShowGauges",
+					"OpposingTeamLabelsShowNames",
+					"ScoreTableVisibility",
+					"SmallScoreTableVisibility",
+					"TeamLabelsShowGauges",
+					"TeamLabelsShowNames"
+				],
+				"Ident": [
+					"ScoreSummary_Player1",
+					"ScoreSummary_Player2",
+					"SpectatorAutoTarget",
+					"SpectatorForcedTarget"
+				],
+				"Integer": [
+					"AlliesLabelsMaxCount",
+					"BigMessageSoundVariant",
+					"CountdownEndTime",
+					"GaugeClan",
+					"OverlayChatLineCount",
+					"ScoreSummary_MatchPoints1",
+					"ScoreSummary_MatchPoints2",
+					"ScoreSummary_Points1",
+					"ScoreSummary_Points2",
+					"ScoreSummary_RoundPoints1",
+					"ScoreSummary_RoundPoints2",
+					"SpectatorForceCameraType",
+					"SpectatorForcedClan",
+					"UISequence_CustomMTRefTime"
+				],
+				"Real": [
+					"GaugeRatio",
+					"ScoreSummary_Gauge1",
+					"ScoreSummary_Gauge2",
+					"SpectatorCamAutoLatitude",
+					"SpectatorCamAutoLongitude",
+					"SpectatorCamAutoRadius"
+				],
+				"Text": [
+					"BigMessage",
+					"BigMessageAvatarLogin",
+					"GaugeMessage",
+					"ManialinkPage",
+					"MarkersXML",
+					"ScoreTable",
+					"SmallScoreTable",
+					"StatusMessage",
+					"UISequence_CustomMTClip",
+					"UISequence_PodiumPlayersLose",
+					"UISequence_PodiumPlayersWin"
+				],
+				"Vec2": [
+					"CountdownCoord",
+					"OverlayChatOffset"
+				]
+			},
+			"methods": [
+				{
+					"name": "SendChat",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						}
+					]
+				},
+				{
+					"name": "SendNotice",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Text"
+						},
+						{
+							"identifier": "ENoticeLevel",
+							"argument": "Level"
+						},
+						{
+							"identifier": "CUser",
+							"argument": "Avatar"
+						},
+						{
+							"identifier": "EAvatarVariant",
+							"argument": "AvatarVariant"
+						},
+						{
+							"identifier": "EUISound",
+							"argument": "Sound"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "SoundVariant"
+						}
+					]
+				},
+				{
+					"name": "GetLayerManialinkAction",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "CUILayer",
+							"argument": "Layer"
+						}
+					]
+				},
+				{
+					"name": "ClearLayerManialinkAction",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUILayer",
+							"argument": "Layer"
+						}
+					]
+				}
+			]
+		},
+		"CUIConfigEvent": {
+			"props": {
+				"CUIConfig": [
+					"UI"
+				],
+				"CUILayer": [
+					"CustomEventLayer"
+				],
+				"EModuleType": [
+					"ModuleType"
+				],
+				"EType": [
+					"Type"
+				],
+				"Integer": [
+					"Quantity"
+				],
+				"Text": [
+					"CustomEventType",
+					"ItemUrl",
+					"Param1"
+				],
+				"Text[]": [
+					"CustomEventData",
+					"Param2"
+				]
+			},
+			"methods": []
+		},
+		"CUIConfigMgr": {
+			"props": {
+				"Boolean": [
+					"HoldLoadingScreen"
+				],
+				"CUIConfig": [
+					"UIAll"
+				],
+				"CUIConfig[]": [
+					"UI"
+				],
+				"CUIConfigEvent[]": [
+					"PendingEvents"
+				],
+				"CUILayer[]": [
+					"UILayers",
+					"UIReplayLayers"
+				],
+				"Integer": [
+					"UISequenceMaxDuration"
+				]
+			},
+			"methods": [
+				{
+					"name": "ResetAll",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "GetUI",
+					"returns": "CUIConfig",
+					"params": [
+						{
+							"identifier": "CPlayer",
+							"argument": "Player"
+						}
+					]
+				},
+				{
+					"name": "GetUI",
+					"returns": "CUIConfig",
+					"params": [
+						{
+							"identifier": "CUser",
+							"argument": "User"
+						}
+					]
+				},
+				{
+					"name": "GetUI",
+					"returns": "CUIConfig",
+					"params": [
+						{
+							"identifier": "CClient",
+							"argument": "Client"
+						}
+					]
+				},
+				{
+					"name": "UILayerCreate",
+					"returns": "CUILayer",
+					"params": []
+				},
+				{
+					"name": "UILayerDestroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CUILayer",
+							"argument": "Layer"
+						}
+					]
+				},
+				{
+					"name": "UILayerDestroyAll",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CUILayer": {
+			"props": {
+				"Boolean": [
+					"AnimInProgress",
+					"IsLocalPageScriptRunning",
+					"IsVisible"
+				],
+				"CMlPage": [
+					"LocalPage"
+				],
+				"EUILayerAnimation": [
+					"InAnimation",
+					"InOutAnimation",
+					"OutAnimation"
+				],
+				"EUILayerType": [
+					"Type"
+				],
+				"Text": [
+					"AttachId",
+					"ManialinkPage"
+				]
+			},
+			"methods": []
+		},
+		"CUser": {
+			"props": {
+				"Boolean": [
+					"HackCamHmdDisabled",
+					"IsBeginner",
+					"IsConnectedToMasterServer",
+					"IsFakeUser",
+					"VoiceChat_IsMuted",
+					"VoiceChat_IsSpeaking",
+					"VoiceChat_Supported"
+				],
+				"EEchelon": [
+					"Echelon"
+				],
+				"EMuteSetting": [
+					"VoiceChat_MuteSetting"
+				],
+				"EStereoDisplayMode": [
+					"StereoDisplayMode"
+				],
+				"ETagType[]": [
+					"Tags_Type"
+				],
+				"Integer": [
+					"FameStars",
+					"LadderRank",
+					"LadderTotal",
+					"NextEchelonPercent"
+				],
+				"Integer[]": [
+					"Tags_Favored_Indices"
+				],
+				"Real": [
+					"LadderPoints",
+					"ReferenceScore"
+				],
+				"Text": [
+					"AvatarUrl",
+					"BroadcastTVLogin",
+					"ClubLink",
+					"CountryFlagUrl",
+					"Description",
+					"LadderZoneFlagUrl",
+					"LadderZoneName",
+					"Language",
+					"Login",
+					"Name",
+					"SteamUserId",
+					"ZoneFlagUrl",
+					"ZonePath"
+				],
+				"Text[]": [
+					"AlliesConnected",
+					"Tags_Comments",
+					"Tags_Deliverer",
+					"Tags_Id"
+				],
+				"Vec3": [
+					"Color"
+				]
+			},
+			"methods": []
+		},
+		"CUserV2": {
+			"props": {
+				"Boolean": [
+					"PersistentIsReady"
+				],
+				"CUserV2Profile": [
+					"Config"
+				],
+				"Text": [
+					"DisplayName",
+					"SystemName"
+				],
+				"Vec3": [
+					"Color"
+				]
+			},
+			"methods": [
+				{
+					"name": "PersistentSave",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CUserV2Manager": {
+			"props": {
+				"Boolean": [
+					"MainUserLogged"
+				],
+				"CInputPad": [
+					"MainUserPad"
+				],
+				"CTaskResult[]": [
+					"TaskResults"
+				],
+				"CUserV2": [
+					"MainUser"
+				],
+				"CUserV2[]": [
+					"Users"
+				]
+			},
+			"methods": [
+				{
+					"name": "TaskResult_Release",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "TaskId"
+						}
+					]
+				},
+				{
+					"name": "RequestMainUserChange",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "GetGroups",
+					"returns": "CTaskResult_StringIntList",
+					"params": [
+						{
+							"identifier": "Ident",
+							"argument": "UserId"
+						}
+					]
+				}
+			]
+		},
+		"CUserV2Profile": {
+			"props": {
+				"EMapEditorMode": [
+					"MapEditorMode"
+				]
+			},
+			"methods": []
+		},
+		"CVideo": {
+			"props": {
+				"Boolean": [
+					"AutoProcessing",
+					"DownloadInProgress",
+					"IsLooping",
+					"IsPlaying",
+					"IsProcessing"
+				],
+				"CImage": [
+					"Image"
+				],
+				"ETextureFilter": [
+					"TextureFilter"
+				],
+				"Real": [
+					"PlayCursor",
+					"PlayLength"
+				]
+			},
+			"methods": [
+				{
+					"name": "BeginProcessing",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "EndProcessing",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Play",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Pause",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "Stop",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CVideoManager": {
+			"props": {
+				"CVideo[]": [
+					"Videos"
+				]
+			},
+			"methods": [
+				{
+					"name": "CreateVideo",
+					"returns": "CVideo",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Url"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "IsLooping"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "AutoProcessing"
+						}
+					]
+				},
+				{
+					"name": "DestroyVideo",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CVideo",
+							"argument": "Video"
+						}
+					]
+				}
+			]
+		},
+		"CWebServicesTaskResult_MapRecordListScript": {
+			"props": {
+				"CGamePlayerMapRecordScript[]": [
+					"MapRecordList"
+				]
+			},
+			"methods": []
+		},
+		"CWebServicesTaskResult_NaturalLeaderBoardInfoList": {
+			"props": {},
+			"methods": []
+		},
+		"CWebServicesTaskResult_PlayerMapRecords": {
+			"props": {},
+			"methods": []
+		},
+		"CWebServicesTaskResult_RealLeaderBoardInfoList": {
+			"props": {},
+			"methods": []
+		},
+		"CXmlDocument": {
+			"props": {
+				"CXmlNode": [
+					"Root"
+				],
+				"CXmlNode[]": [
+					"Nodes"
+				],
+				"Text": [
+					"TextContents"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetFirstChild",
+					"returns": "CXmlNode",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						}
+					]
+				}
+			]
+		},
+		"CXmlManager": {
+			"props": {
+				"CXmlDocument[]": [
+					"Documents"
+				],
+				"Integer": [
+					"DocumentsSlotsLimit"
+				]
+			},
+			"methods": [
+				{
+					"name": "Create",
+					"returns": "CXmlDocument",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Contents"
+						}
+					]
+				},
+				{
+					"name": "Create",
+					"returns": "CXmlDocument",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Contents"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "GenerateText"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "GenerateTextRaw"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "GenerateTextResursive"
+						}
+					]
+				},
+				{
+					"name": "Destroy",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "CXmlDocument",
+							"argument": "Document"
+						}
+					]
+				}
+			]
+		},
+		"CXmlNode": {
+			"props": {
+				"CXmlNode[]": [
+					"Children"
+				],
+				"Text": [
+					"Name",
+					"TextContents",
+					"TextRawContents",
+					"TextRecursiveContents"
+				]
+			},
+			"methods": [
+				{
+					"name": "GetAttributeText",
+					"returns": "Text",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						},
+						{
+							"identifier": "Text",
+							"argument": "DefaultValue"
+						}
+					]
+				},
+				{
+					"name": "GetAttributeInteger",
+					"returns": "Integer",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						},
+						{
+							"identifier": "Integer",
+							"argument": "DefaultValue"
+						}
+					]
+				},
+				{
+					"name": "GetAttributeReal",
+					"returns": "Real",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						},
+						{
+							"identifier": "Real",
+							"argument": "DefaultValue"
+						}
+					]
+				},
+				{
+					"name": "GetAttributeBoolean",
+					"returns": "Boolean",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						},
+						{
+							"identifier": "Boolean",
+							"argument": "DefaultValue"
+						}
+					]
+				},
+				{
+					"name": "GetFirstChild",
+					"returns": "CXmlNode",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Name"
+						}
+					]
+				}
+			]
+		},
+		"CXmlRpc": {
+			"props": {
+				"CXmlRpcEvent[]": [
+					"PendingEvents"
+				]
+			},
+			"methods": [
+				{
+					"name": "SendCallback",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Param1"
+						},
+						{
+							"identifier": "Text",
+							"argument": "Param2"
+						}
+					]
+				},
+				{
+					"name": "SendCallbackArray",
+					"returns": "Void",
+					"params": [
+						{
+							"identifier": "Text",
+							"argument": "Type"
+						},
+						{
+							"identifier": "Text[]",
+							"argument": "Data"
+						}
+					]
+				},
+				{
+					"name": "SendCallback_BeginRound",
+					"returns": "Void",
+					"params": []
+				},
+				{
+					"name": "SendCallback_EndRound",
+					"returns": "Void",
+					"params": []
+				}
+			]
+		},
+		"CXmlRpcEvent": {
+			"props": {
+				"EType": [
+					"Type"
+				],
+				"Text": [
+					"Param1",
+					"Param2",
+					"ParamArray1"
+				],
+				"Text[]": [
+					"ParamArray2"
+				]
+			},
+			"methods": []
+		}
+	}
 }

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -7392,6 +7392,561 @@
         ]
       }
     },
+    "CSmAction": {
+      "props": {
+        "Integer": [
+          "Now",
+          "Variant",
+          "Energy",
+          "EnergyMax",
+          "EnergyCost",
+          "State_Integer1",
+          "Cooldown"
+        ],
+        "CSmPlayer[]": [
+          "Players"
+        ],
+        "CSmPlayer": [
+          "Owner"
+        ],
+        "Boolean": [
+          "IsActive",
+          "IsBound",
+          "EnergyReload",
+          "State_Boolean1",
+          "IsJumping",
+          "IsGliding",
+          "IsAttractor",
+          "IsFlying",
+          "IsSliding",
+          "IsRunning",
+          "IsFrozen",
+          "IsSneaking",
+          "IsFreeLooking",
+          "HasNoPlayerCollision"
+        ],
+        "Real": [
+          "AmmoGain"
+        ],
+        "Ident": [
+          "State_EntityId1"
+        ],
+        "CSmActionEvent[]": [
+          "PendingEvents"
+        ]
+      },
+      "methods": {
+        "SendRulesEvent": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Param1"
+            },
+            {
+              "identifier": "Text[]",
+              "argument": "Param2"
+            },
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Shooter"
+            },
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Victim"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Anim_GetModelId": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ModelName"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Anim_PlayAtPosition": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "AnimModelId"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Direction"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Anim_PlayOnPlayer": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "AnimModelId"
+            },
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Anim_Stop": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "AnimId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Projectile_GetModelId": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ModelName"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Projectile_CreateAtLocation": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ProjectileModelId"
+            },
+            {
+              "identifier": "CSmPlayer",
+              "argument": "PlayerToIgnore"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "InitialPosition"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "InitialDirection"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "InitialVelocity"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Projectile_CreateOnPlayer": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ProjectileModelId"
+            },
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Shooter"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Cooldown_IsReady": {
+          "params": [],
+          "returns": "Boolean"
+        },
+        "Cooldown_Start": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Shield_CreateAtLocation": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Direction"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Shield_CreateOnPlayer": {
+          "params": [
+            {
+              "identifier": "CSmPlayer",
+              "argument": "ShieldOwner"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "Shield_Destroy": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Shield_Exists": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Shield_GetArmor": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Shield_SetArmor": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "ShieldArmor"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Shield_GetIsActive": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Shield_SetIsActive": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "SheildIsActive"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Shield_GetArmorMax": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Shield_GetTickReload": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "Shield_GetCooldown": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ShieldId"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetPlayerAmmo": {
+          "params": [
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetPlayerAmmoMax": {
+          "params": [
+            {
+              "identifier": "CSmPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Integer"
+        }
+      }
+    },
+    "CSmActionEvent": {
+      "props": {
+        "EType": [
+          "Type"
+        ],
+        "CSmPlayer": [
+          "Player"
+        ],
+        "CSmObject": [
+          "Object"
+        ],
+        "Integer": [
+          "Damage",
+          "ContextId",
+          "Shield"
+        ],
+        "Ident": [
+          "ProjectileModelId"
+        ],
+        "Vec3": [
+          "Position",
+          "Direction",
+          "Normal"
+        ]
+      }
+    },
+    "CSmBase": {
+      "props": {
+        "Integer": [
+          "Clan",
+          "NumberOfCollectors"
+        ],
+        "Boolean": [
+          "IsActive"
+        ]
+      }
+    },
+    "CSmBlock": {
+      "props": {
+        "CSmBase": [
+          "Base"
+        ]
+      }
+    },
+    "CSmBlockPole": {
+      "props": {
+        "Boolean": [
+          "Captured"
+        ],
+        "CSmSector": [
+          "Sector"
+        ],
+        "CSmGauge": [
+          "Gauge"
+        ]
+      }
+    },
+    "CSmGauge": {
+      "props": {
+        "Integer": [
+          "Clan",
+          "Value",
+          "Max",
+          "Speed"
+        ],
+        "Real": [
+          "ValueReal"
+        ]
+      }
+    },
+    "CSmLandmark": {
+      "props": {
+        "Text": [
+          "Tag"
+        ],
+        "Integer": [
+          "Order"
+        ],
+        "Vec3": [
+          "Position",
+          "DirFront"
+        ]
+      }
+    },
+    "CSmMapBase": {
+      "props": {
+        "Integer": [
+          "Clan",
+          "NumberOfCollectors"
+        ],
+        "Boolean": [
+          "IsActive"
+        ]
+      }
+    },
+    "CSmMapBotPath": {
+      "props": {
+        "Integer": [
+          "Clan"
+        ],
+        "Vec3[]": [
+          "Path"
+        ],
+        "Boolean": [
+          "IsFlying"
+        ]
+      }
+    },
+    "CSmMapBotSpawn": {
+      "props": {
+        "Boolean": [
+          "IsFlying"
+        ],
+        "Ident": [
+          "BotModelId"
+        ]
+      }
+    },
+    "CSmMapGate": {
+      "props": {
+        "Integer": [
+          "Clan",
+          "AutoCloseDelay",
+          "AutoOpenSpeed"
+        ],
+        "Boolean": [
+          "Automatic",
+          "ManualClosed",
+          "AutoClosed",
+          "AutoIsActive"
+        ]
+      }
+    },
+    "CSmMapGauge": {
+      "props": {
+        "Integer": [
+          "Clan",
+          "Value",
+          "Max",
+          "Speed"
+        ],
+        "Real": [
+          "ValueReal"
+        ],
+        "Boolean": [
+          "Captured"
+        ]
+      }
+    },
+    "CSmMapLandmark": {
+      "props": {
+        "Text": [
+          "Tag"
+        ],
+        "Integer": [
+          "Order"
+        ],
+        "Vec3": [
+          "Position"
+        ],
+        "CSmMapBase": [
+          "Base"
+        ],
+        "CSmMapGate": [
+          "Gate"
+        ],
+        "CSmMapGauge": [
+          "Gauge"
+        ],
+        "CSmMapSector": [
+          "Sector"
+        ],
+        "CSmMapPlayerSpawn": [
+          "PlayerSpawn"
+        ],
+        "CSmMapBotPath": [
+          "BotPath"
+        ],
+        "CSmMapBotSpawn": [
+          "BotSpawn"
+        ],
+        "CSmMapObjectAnchor": [
+          "ObjectAnchor"
+        ]
+      }
+    },
+    "CSmMapObjectAnchor": {
+      "props": {
+        "Text": [
+          "ItemName"
+        ],
+        "Ident": [
+          "ItemModelId"
+        ]
+      }
+    },
+    "CSmMapPlayerSpawn": {
+      "props": {}
+    },
+    "CSmMapSector": {
+      "props": {
+        "Ident[]": [
+          "PlayersIds"
+        ],
+        "Text": [
+          "Tag"
+        ]
+      }
+    },
+    "CSmMapType": {
+      "props": {
+        "CSmMode": [
+          "Mode"
+        ],
+        "CSmPlayer[]": [
+          "AllPlayers",
+          "Players"
+        ]
+      }
+    },
+    "CSmMlScriptIngame": {
+      "props": {
+        "Integer": [
+          "ArenaNow"
+        ],
+        "CSmPlayer": [
+          "InputPlayer",
+          "GUIPlayer"
+        ],
+        "CSmPlayer[]": [
+          "Players"
+        ],
+        "CSmScore[]": [
+          "Scores"
+        ],
+        "Integer[]": [
+          "ClanScores"
+        ],
+        "Boolean": [
+          "HideResumePlayingButton"
+        ],
+        "CSmMapBase[]": [
+          "MapBases"
+        ],
+        "CSmMapLandmark[]": [
+          "MapLandmarks",
+          "MapLandmarks_PlayerSpawn",
+          "MapLandmarks_Gauge",
+          "MapLandmarks_Sector",
+          "MapLandmarks_BotPath",
+          "MapLandmarks_BotSpawn",
+          "MapLandmarks_ObjectAnchor",
+          "MapLandmarks_Gate"
+        ]
+      }
+    },
     "CSmMode": {
       "props": {
         "Integer": [
@@ -8017,207 +8572,6 @@
         }
       }
     },
-    "CSmMlScriptIngame": {
-      "props": {
-        "Integer": [
-          "ArenaNow"
-        ],
-        "CSmPlayer": [
-          "InputPlayer",
-          "GUIPlayer"
-        ],
-        "CSmPlayer[]": [
-          "Players"
-        ],
-        "CSmScore[]": [
-          "Scores"
-        ],
-        "Integer[]": [
-          "ClanScores"
-        ],
-        "Boolean": [
-          "HideResumePlayingButton"
-        ],
-        "CSmMapBase[]": [
-          "MapBases"
-        ],
-        "CSmMapLandmark[]": [
-          "MapLandmarks",
-          "MapLandmarks_PlayerSpawn",
-          "MapLandmarks_Gauge",
-          "MapLandmarks_Sector",
-          "MapLandmarks_BotPath",
-          "MapLandmarks_ObjectAnchor",
-          "MapLandmarks_Gate"
-        ]
-      }
-    },
-    "CSmAction": {
-      "props": {
-        "Integer": [
-          "Now",
-          "Variant",
-          "Energy",
-          "EnergyMax",
-          "EnergyCost",
-          "Cooldown"
-        ],
-        "CSmPlayer[]": [
-          "Players"
-        ],
-        "CSmPlayer": [
-          "Owner"
-        ],
-        "Boolean": [
-          "IsActive",
-          "EnergyReload"
-        ],
-        "CSmActionEvent[]": [
-          "PendingEvents"
-        ]
-      },
-      "methods": {
-        "SendRulesEvent": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Param1"
-            },
-            {
-              "identifier": "Text[]",
-              "argument": "Param2"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Victim"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetAnimModelId": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "PlayAnimOnPlayer": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "AnimModelId"
-            },
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "PlayAnimAtPosition": {
-          "params": [
-            {
-              "identifier": "Ident",
-              "argument": "AnimModelId"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Position"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "Direction"
-            }
-          ],
-          "returns": "Void"
-        },
-        "GetProjectileModelId": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "CreateProjectile": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "PlayerToIgnore"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ProjectileModelId"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialPosition"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialDirection"
-            },
-            {
-              "identifier": "Vec3",
-              "argument": "InitialVelocity"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ContextId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CreateShoot": {
-          "params": [
-            {
-              "identifier": "CSmPlayer",
-              "argument": "Shooter"
-            },
-            {
-              "identifier": "Ident",
-              "argument": "ProjectileModelId"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "ContextId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Cooldown_IsReady": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Now"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Cooldown_Start": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CSmMapType": {
-      "props": {
-        "CSmMode": [
-          "Mode"
-        ],
-        "CSmPlayer[]": [
-          "AllPlayers",
-          "Players"
-        ]
-      }
-    },
     "CTmMlScriptIngame": {
       "props": {
         "CTmMlPlayer": [
@@ -8685,51 +9039,6 @@
         ]
       }
     },
-    "CSmMapBase": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "NumberOfCollectors"
-        ],
-        "Boolean": [
-          "IsActive"
-        ]
-      }
-    },
-    "CSmMapLandmark": {
-      "props": {
-        "Text": [
-          "Tag"
-        ],
-        "Integer": [
-          "Order"
-        ],
-        "Vec3": [
-          "Position"
-        ],
-        "CSmMapBase": [
-          "Base"
-        ],
-        "CSmMapGate": [
-          "Gate"
-        ],
-        "CSmMapGauge": [
-          "Gauge"
-        ],
-        "CSmMapSector": [
-          "Sector"
-        ],
-        "CSmMapPlayerSpawn": [
-          "PlayerSpawn"
-        ],
-        "CSmMapBotPath": [
-          "BotPath"
-        ],
-        "CSmMapObjectAnchor": [
-          "ObjectAnchor"
-        ]
-      }
-    },
     "CSmScore": {
       "props": {
         "Integer": [
@@ -8817,28 +9126,6 @@
           "params": [],
           "returns": "Void"
         }
-      }
-    },
-    "CSmActionEvent": {
-      "props": {
-        "EType": [
-          "Type"
-        ],
-        "CSmPlayer": [
-          "Player"
-        ],
-        "Integer": [
-          "Damage",
-          "ContextId"
-        ],
-        "Ident": [
-          "ProjectileModelId"
-        ],
-        "Vec3": [
-          "Position",
-          "Direction",
-          "Normal"
-        ]
       }
     },
     "CTmMlPlayer": {
@@ -9170,80 +9457,7 @@
         ]
       }
     },
-    "CSmMapSector": {
-      "props": {
-        "Ident[]": [
-          "PlayersIds"
-        ]
-      }
-    },
-    "CSmBlockPole": {
-      "props": {
-        "Boolean": [
-          "Captured"
-        ],
-        "CSmSector": [
-          "Sector"
-        ],
-        "CSmGauge": [
-          "Gauge"
-        ]
-      }
-    },
-    "CSmMapGate": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "AutoCloseDelay",
-          "AutoOpenSpeed"
-        ],
-        "Boolean": [
-          "Automatic",
-          "ManualClosed",
-          "AutoClosed",
-          "AutoIsActive"
-        ]
-      }
-    },
-    "CSmMapGauge": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "Value",
-          "Max",
-          "Speed"
-        ],
-        "Real": [
-          "ValueReal"
-        ],
-        "Boolean": [
-          "Captured"
-        ]
-      }
-    },
-    "CSmMapBotPath": {
-      "props": {
-        "Integer": [
-          "Clan"
-        ],
-        "Vec3[]": [
-          "Path"
-        ],
-        "Boolean": [
-          "IsFlying"
-        ]
-      }
-    },
-    "CSmMapObjectAnchor": {
-      "props": {
-        "Text": [
-          "ItemName"
-        ],
-        "Ident": [
-          "ItemModelId"
-        ]
-      }
-    },
+
     "CUIConfig": {
       "props": {
         "EUISequence": [
@@ -9548,55 +9762,10 @@
         ]
       }
     },
-    "CSmBlock": {
-      "props": {
-        "CSmBase": [
-          "Base"
-        ]
-      }
-    },
     "CSmSector": {
       "props": {
         "Ident[]": [
           "PlayersIds"
-        ]
-      }
-    },
-    "CSmGauge": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "Value",
-          "Max",
-          "Speed"
-        ],
-        "Real": [
-          "ValueReal"
-        ]
-      }
-    },
-    "CSmLandmark": {
-      "props": {
-        "Text": [
-          "Tag"
-        ],
-        "Integer": [
-          "Order"
-        ],
-        "Vec3": [
-          "Position",
-          "DirFront"
-        ]
-      }
-    },
-    "CSmBase": {
-      "props": {
-        "Integer": [
-          "Clan",
-          "NumberOfCollectors"
-        ],
-        "Boolean": [
-          "IsActive"
         ]
       }
     },

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -5209,8 +5209,134 @@
         ]
       }
     },
+    "CMlScriptIngame": {
+      "props": {
+        "Integer": [
+          "GameTime"
+        ],
+        "CPlaygroundClient": [
+          "Playground"
+        ],
+        "CUIConfig": [
+          "UI",
+          "ClientUI"
+        ],
+        "Boolean": [
+          "IsSpectator",
+          "IsSpectatorClient",
+          "UseClans",
+          "UseForcedClans",
+          "IsInGameMenuDisplayed"
+        ],
+        "CManiaAppPlaygroundCommon": [
+          "ParentApp"
+        ],
+        "CMap": [
+          "Map"
+        ],
+        "CTeam[]": [
+          "Teams"
+        ],
+        "Text": [
+          "CurrentServerLogin",
+          "CurrentServerName",
+          "CurrentServerDesc",
+          "CurrentServerJoinLink",
+          "CurrentServerModeName"
+        ],
+        "CAchievementsManager": [
+          "AchievementsManager"
+        ]
+      },
+      "methods": {
+        "ShowCurChallengeCard": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ShowModeHelp": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CopyServerLinkToClipBoard": {
+          "params": [],
+          "returns": "Void"
+        },
+        "JoinTeam1": {
+          "params": [],
+          "returns": "Void"
+        },
+        "JoinTeam2": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestSpectatorClient": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "Spectator"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetSpectateTarget": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ShowProfile": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ShowInGameMenu": {
+          "params": [],
+          "returns": "Void"
+        },
+        "CloseInGameMenu": {
+          "params": [
+            {
+              "identifier": "EInGameMenuResult",
+              "argument": "Result"
+            }
+          ],
+          "returns": "Void"
+        },
+        "CloseScoresTable": {
+          "params": [],
+          "returns": "Void"
+        },
+        "PlayUiSound": {
+          "params": [
+            {
+              "identifier": "EUISound",
+              "argument": "Sound"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "SoundVariant"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Volume"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
     "CMlStation": {
       "props": {
+        "CManiaAppStation": [
+          "ParentApp"
+        ],
         "CStation": [
           "Station"
         ]
@@ -5218,6 +5344,790 @@
       "methods": {
         "EnterStation": {
           "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlTextEdit": {
+      "props": {
+        "Text": [
+          "Value"
+        ],
+        "Integer": [
+          "MaxLine",
+          "ValueLineCount"
+        ],
+        "Boolean": [
+          "AutoNewLine",
+          "ShowLineNumbers"
+        ],
+        "Real": [
+          "LineSpacing",
+          "Opacity",
+          "TextSizeReal"
+        ],
+        "Vec3": [
+          "TextColor"
+        ],
+        "EControlScriptEditorTextFormat": [
+          "TextFormat"
+        ]
+      },
+      "methods": {
+        "StartEdition": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMode": {
+      "props": {
+        "Text": [
+          "ModeStatusMessage",
+          "ServerLogin",
+          "ServerName",
+          "ServerModeName",
+          "MapName",
+          "MapPlayerModelName",
+          "NeutralEmblemUrl",
+          "ForcedClubLinkUrl1",
+          "ForcedClubLinkUrl2",
+          "ClientManiaAppUrl"
+        ],
+        "CTitle": [
+          "LoadedTitle"
+        ],
+        "CMap": [
+          "Map"
+        ],
+        "CUser[]": [
+          "Users"
+        ],
+        "CTeam[]": [
+          "Teams"
+        ],
+        "Integer": [
+          "Now",
+          "Period",
+          "NextMapIndex"
+        ],
+        "Boolean": [
+          "MatchEndRequested",
+          "ServerShutdownRequested",
+          "MapLoaded",
+          "Ladder_RequestInProgress",
+          "Solo_NewRecordSequenceInProgress",
+          "UseMinimap",
+          "Replay_AutoStart"
+        ],
+        "CMapInfo[]": [
+          "MapList"
+        ],
+        "CUIConfigMgr": [
+          "UIManager"
+        ],
+        "CModulePlaygroundHud": [
+          "Hud"
+        ],
+        "CServerAdmin": [
+          "ServerAdmin"
+        ],
+        "CXmlRpc": [
+          "XmlRpc"
+        ],
+        "CXmlManager": [
+          "Xml"
+        ],
+        "CHttpManager": [
+          "Http"
+        ],
+        "CInputManager": [
+          "Input"
+        ],
+        "CDataFileMgr": [
+          "DataFileMgr"
+        ],
+        "CScoreMgr": [
+          "ScoreMgr"
+        ],
+        "ESystemPlatform": [
+          "SystemPlatform"
+        ],
+        "CAchievementsManager": [
+          "AchievementsManager"
+        ],
+        "CModeTurretManager": [
+          "TurretsManager"
+        ]
+      },
+      "methods": {
+        "TweakTeamColorsToAvoidHueOverlap": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestLoadMap": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestUnloadMap": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Hud_Load": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ModuleName"
+            }
+          ],
+          "returns": "Void"
+        },
+        "PassOn": {
+          "params": [
+            {
+              "identifier": "CUIConfigEvent",
+              "argument": "EventToPassOn"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Discard": {
+          "params": [
+            {
+              "identifier": "CUIConfigEvent",
+              "argument": "EventToDiscard"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ladder_OpenMatch_Request": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Ladder_AddPlayer": {
+          "params": [
+            {
+              "identifier": "CScore",
+              "argument": "PlayerScore"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ladder_OpenMatch_BeginRequest": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Ladder_OpenMatch_AddPlayer": {
+          "params": [
+            {
+              "identifier": "CScore",
+              "argument": "PlayerScore"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ladder_OpenMatch_EndRequest": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Ladder_CloseMatchRequest": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Ladder_CancelMatchRequest": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Ladder_SetResultsVersion": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Version"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ladder_SetMatchMakingMatchId": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "MatchId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Ladder_EnableChallengeMode": {
+          "params": [
+            {
+              "identifier": "Boolean",
+              "argument": "Enable"
+            }
+          ],
+          "returns": "Void"
+        },
+        "AutoTeamBalance": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Solo_SetNewRecord": {
+          "params": [
+            {
+              "identifier": "CScore",
+              "argument": "PlayerScore"
+            },
+            {
+              "identifier": "EMedal",
+              "argument": "PlayerScore"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Synchro_AddBarrier": {
+          "params": [],
+          "returns": "Integer"
+        },
+        "Synchro_BarrierReached": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Barrier"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Users_AreAllies": {
+          "params": [
+            {
+              "identifier": "CUser",
+              "argument": "User1"
+            },
+            {
+              "identifier": "CUser",
+              "argument": "User2"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Users_RequestSwitchToSpectator": {
+          "params": [
+            {
+              "identifier": "CUser",
+              "argument": "User"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Users_CreateFake": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "NickName"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "RequestedTeam"
+            }
+          ],
+          "returns": "CUser"
+        },
+        "Users_DestroyFake": {
+          "params": [
+            {
+              "identifier": "CUser",
+              "argument": "User"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Users_SetNbFakeUsers": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "NbTeam1"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "NbTeam2"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Users_DestroyAllFakes": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ItemList_Begin": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ItemList_Add": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ModelName"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "ItemList_AddWithSkin": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ModelName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "SkinName"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "ItemList_End": {
+          "params": [],
+          "returns": "Void"
+        },
+        "DemoToken_StartUsingToken": {
+          "params": [],
+          "returns": "Void"
+        },
+        "DemoToken_StopUsingToken": {
+          "params": [],
+          "returns": "Void"
+        },
+        "DemoToken_GetAndUseToken": {
+          "params": [
+            {
+              "identifier": "CUser",
+              "argument": "User"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ActionList_Begin": {
+          "params": [],
+          "returns": "Void"
+        },
+        "ActionList_Add": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ActionName"
+            }
+          ],
+          "returns": "Ident"
+        },
+        "ActionList_End": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Replay_Start": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Replay_Stop": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Dbg_DumpDeclareForVariables": {
+          "params": [
+            {
+              "identifier": "CNod",
+              "argument": "Nod"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "StatsOnly"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModeTurret": {
+      "props": {
+        "Integer": [
+          "Armor",
+          "ArmorMax"
+        ],
+        "CModeTurret": [
+          "Owner"
+        ]
+      }
+    },
+    "CModeTurretManager": {
+      "props": {
+        "CModeTurret[]": [
+          "Turrets"
+        ]
+      },
+      "methods": {
+        "MapTurrets_Reset": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Turret_Create": {
+          "params": [
+            {
+              "identifier": "Ident",
+              "argument": "ModelId"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Position"
+            },
+            {
+              "identifier": "Vec3",
+              "argument": "Direction"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Clan"
+            },
+            {
+              "identifier": "CPlayer",
+              "argument": "Owner"
+            }
+          ],
+          "returns": "CModeTurret"
+        },
+        "Turret_Destroy": {
+          "params": [
+            {
+              "identifier": "CModeTurret",
+              "argument": "Turret"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModuleMenu": {
+      "methods": {
+        "Menu_Goto": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "PageId"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Menu_Back": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Previous": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Menu_Quit": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModuleMenuComponent": {
+      "props": {
+        "CUILayer": [
+          "ComponentLayer"
+        ]
+      },
+      "methods": {
+        "Hide": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Show": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModuleMenuFileBrowser": {
+      "props": {
+        "Boolean": [
+          "HesFinished"
+        ],
+        "Text[]": [
+          "Selection"
+        ]
+      },
+      "methods": {
+        "SetFileType": {
+          "params": [
+            {
+              "identifier": "EFileType",
+              "argument": "FileType"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetFileAction": {
+          "params": [
+            {
+              "identifier": "EFileAction",
+              "argument": "FileAction"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModuleMenuLayer": {
+      "props": {
+        "CModuleMenuComponent[]": [
+          "Components"
+        ]
+      },
+      "methods": {
+        "GetFirstComponent": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Name"
+            }
+          ],
+          "returns": "CModuleMenuComponent"
+        }
+      }
+    },
+    "CModuleMenuModel": {
+      "props": {
+        "CModuleMenuPageModel[]": [
+          "Pages"
+        ],
+        "Text": [
+          "MenuScript"
+        ]
+      },
+      "methods": {
+        "AddPage": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "PageUrl"
+            }
+          ],
+          "returns": "CModuleMenuPageModel"
+        },
+        "AddLink": {
+          "params": [
+            {
+              "identifier": "CModuleMenuPageModel",
+              "argument": "ParentPage"
+            },
+            {
+              "identifier": "CModuleMenuPageModel",
+              "argument": "ChildPage"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CModuleMenuPageModel": {
+      "props": {
+        "Text": [
+          "ManialinkText"
+        ]
+      }
+    },
+    "CModulePlayground": {
+      "methods": {
+        "Hide": {
+          "params": [
+            {
+              "identifier": "CUIConfig",
+              "argument": "UIConfig"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Show": {
+          "params": [
+            {
+              "identifier": "CUIConfig",
+              "argument": "UIConfig"
+            }
+          ],
+          "returns": "Void"
+        },
+        "IsVisble": {
+          "params": [
+            {
+              "identifier": "CUIConfig",
+              "argument": "UIConfig"
+            }
+          ],
+          "returns": "Boolean"
+        }
+      }
+    },
+    "CModulePlaygroundHud": {
+      "props": {
+        "CModulePlaygroundInventory": [
+          "Inventory"
+        ],
+        "CModulePlaygroundStore": [
+          "Store"
+        ],
+        "CModulePlaygroundScoresTable": [
+          "ScoresTable"
+        ]
+      }
+    },
+    "CModulePlaygroundInventory": {
+      "methods": {
+        "AddItem": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Quantity"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "AddAction": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "RemoveInventoryItem": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            },
+            {
+              "identifier": "Integer",
+              "argument": "Quantity"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "GetInventoryItemQuantity": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Integer"
+        },
+        "IsInventoryItemStored": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            },
+            {
+              "identifier": "Text",
+              "argument": "Url"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "GetStoredItemsList": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Tex[]"
+        },
+        "GetStoredActionsList": {
+          "params": [
+            {
+              "identifier": "CPlayer",
+              "argument": "Player"
+            }
+          ],
+          "returns": "Tex[]"
+        }
+      }
+    },
+    "CModulePlaygroundScoresTable": {
+      "methods": {
+        "SetFooterText": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FooterText"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ResetCustomColumns": {
+          "params": [
+            {
+              "identifier": "CScore",
+              "argument": "Score"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Scores_Sort": {
+          "params": [
+            {
+              "identifier": "EScoreSortOrder",
+              "argument": "SortOrder"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetColumnValue": {
+          "params": [
+            {
+              "identifier": "CScore",
+              "argument": "Score"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ColumnId"
+            },
+            {
+              "identifier": "Text",
+              "argument": "ColumnValue"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetColumnVisibility": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ColumnId"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Visibility"
+            }
+          ],
           "returns": "Void"
         }
       }
@@ -6362,338 +7272,6 @@
         ]
       }
     },
-    "CMode": {
-      "props": {
-        "Text": [
-          "ModeStatusMessage",
-          "ServerLogin",
-          "ServerName",
-          "ServerModeName",
-          "MapName",
-          "MapPlayerModelName",
-          "NeutralEmblemUrl",
-          "ForcedClubLinkUrl1",
-          "ForcedClubLinkUrl2"
-        ],
-        "CTitle": [
-          "LoadedTitle"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "CUser[]": [
-          "Users"
-        ],
-        "CTeam[]": [
-          "Teams"
-        ],
-        "Integer": [
-          "Now",
-          "Period",
-          "NextMapIndex"
-        ],
-        "Boolean": [
-          "MatchEndRequested",
-          "ServerShutdownRequested",
-          "MapLoaded",
-          "Ladder_RequestInProgress",
-          "Solo_NewRecordSequenceInProgress",
-          "UseMinimap",
-          "Replay_AutoStart"
-        ],
-        "CMapInfo[]": [
-          "MapList"
-        ],
-        "CUIConfigMgr": [
-          "UIManager"
-        ],
-        "CXmlRpc": [
-          "XmlRpc"
-        ],
-        "CXmlManager": [
-          "Xml"
-        ],
-        "CHttpManager": [
-          "Http"
-        ]
-      },
-      "methods": {
-        "TweakTeamColorsToAvoidHueOverlap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestLoadMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestUnloadMap": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_Request": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_AddPlayer": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_BeginRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_AddPlayer": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_OpenMatch_EndRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_CloseMatchRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_CancelMatchRequest": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Ladder_SetResultsVersion": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Version"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_SetMatchMakingMatchId": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "MatchId"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Ladder_EnableChallengeMode": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "Enable"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Admin_KickUser": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            },
-            {
-              "identifier": "Text",
-              "argument": "Reason"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Admin_SetLobbyInfo": {
-          "params": [
-            {
-              "identifier": "Boolean",
-              "argument": "IsLobby"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "LobbyPlayerCount"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "LobbyMaxPlayerCount"
-            },
-            {
-              "identifier": "Real",
-              "argument": "LobbyPlayersLevel"
-            }
-          ],
-          "returns": "Void"
-        },
-        "AutoTeamBalance": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Solo_SetNewRecord": {
-          "params": [
-            {
-              "identifier": "CScore",
-              "argument": "PlayerScore"
-            },
-            {
-              "identifier": "EMedal",
-              "argument": "PlayerScore"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Synchro_AddBarrier": {
-          "params": [],
-          "returns": "Integer"
-        },
-        "Synchro_BarrierReached": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "Barrier"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Users_AreAllies": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User1"
-            },
-            {
-              "identifier": "CUser",
-              "argument": "User2"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "Users_RequestSwitchToSpectator": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_CreateFake": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "NickName"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "RequestedTeam"
-            }
-          ],
-          "returns": "CUser"
-        },
-        "Users_DestroyFake": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_SetNbFakeUsers": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "NbTeam1"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "NbTeam2"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Users_DestroyAllFakes": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ItemList_Begin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ItemList_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ItemList_AddWithSkin": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ModelName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "SkinName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ItemList_End": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_StartUsingToken": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_StopUsingToken": {
-          "params": [],
-          "returns": "Void"
-        },
-        "DemoToken_GetAndUseToken": {
-          "params": [
-            {
-              "identifier": "CUser",
-              "argument": "User"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ActionList_Begin": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ActionList_Add": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ActionName"
-            }
-          ],
-          "returns": "Ident"
-        },
-        "ActionList_End": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_Start": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Replay_Stop": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
     "CSmPlayer": {
       "props": {
         "CSmScore": [
@@ -6981,104 +7559,6 @@
         },
         "SetUnspawned": {
           "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlScriptIngame": {
-      "props": {
-        "Integer": [
-          "GameTime"
-        ],
-        "CUIConfig": [
-          "UI",
-          "ClientUI"
-        ],
-        "Boolean": [
-          "IsSpectatorMode",
-          "UseClans",
-          "UseForcedClans"
-        ],
-        "CMap": [
-          "Map"
-        ],
-        "CTeam[]": [
-          "Teams"
-        ],
-        "Text": [
-          "CurrentServerLogin",
-          "CurrentServerName",
-          "CurrentServerJoinLink",
-          "CurrentServerModeName"
-        ]
-      },
-      "methods": {
-        "ShowCurChallengeCard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "ShowModeHelp": {
-          "params": [],
-          "returns": "Void"
-        },
-        "CopyServerLinkToClipBoard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "JoinTeam1": {
-          "params": [],
-          "returns": "Void"
-        },
-        "JoinTeam2": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetSpectateTarget": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ShowProfile": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Player"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ShowInGameMenu": {
-          "params": [],
-          "returns": "Void"
-        },
-        "PlayUiSound": {
-          "params": [
-            {
-              "identifier": "EUISound",
-              "argument": "Sound"
-            },
-            {
-              "identifier": "Integer",
-              "argument": "SoundVariant"
-            },
-            {
-              "identifier": "Real",
-              "argument": "Volume"
-            }
-          ],
-          "returns": "Void"
-        },
-        "CloseInGameMenu": {
-          "params": [
-            {
-              "identifier": "EInGameMenuResult",
-              "argument": "Result"
-            }
-          ],
           "returns": "Void"
         }
       }

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -4242,6 +4242,744 @@
         ]
       }
     },
+    "CMapEditorPluginLayer": {
+      "props": {
+        "CMapEditorPlugin": [
+          "Editor"
+        ]
+      }
+    },
+    "CMapGroup": {
+      "props": {
+        "CMapInfo[]": [
+          "MapInfos"
+        ]
+      },
+      "methods": {
+        "IsUnlocked": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMapInfo": {
+      "props": {
+        "Text": [
+          "MapUid",
+          "Comments",
+          "CollectionName",
+          "AuthorLogin",
+          "AuthorNickName",
+          "AuthorZonePath",
+          "AuthorZoneFlagUrl",
+          "AuthorCountryFlagUrl",
+          "MapType",
+          "MapStyle",
+          "Name",
+          "Path",
+          "FileName"
+        ],
+        "Integer": [
+          "CopperPrice",
+          "TMObjective_AuthorTime",
+          "TMObjective_GoldTime",
+          "TMObjective_SilverTime",
+          "TMObjective_BronzeTime"
+        ],
+        "Boolean": [
+          "Unlocked",
+          "IsPlayable",
+          "CreatedWithSimpleEditor",
+          "TMObjective_IsLapRace"
+        ]
+      }
+    },
+    "CMapType": {
+      "props": {
+        "Boolean": [
+          "CustomEditAnchorData",
+          "ValidationEndRequested",
+          "ValidationEndNoConfirm",
+          "IsSwitchedToPlayground"
+        ],
+        "ValidationStatus": [
+          "ValidationStatus"
+        ],
+        "Text": [
+          "ValidabilityRequirementsMessage"
+        ],
+        "CUIConfigMgr": [
+          "UIManager"
+        ],
+        "CUser[]": [
+          "Users"
+        ]
+      },
+      "methods": {
+        "ClearMapMetadata": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestEnterPlayground": {
+          "params": [],
+          "returns": "Void"
+        },
+        "RequestLeavePlayground": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMatchSettings": {
+      "props": {
+        "Text": [
+          "Name",
+          "FileName",
+          "ScriptModeName"
+        ],
+        "CGameMatchSettingsPlaylistItemScript[]": [
+          "Playlist"
+        ]
+      },
+      "methods": {
+        "Playlist_FileExists": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "File"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Playlist_FileMatchesMode": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "File"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "Playlist_Add": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "File"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Playlist_Remove": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Index"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Playlist_SwapUd": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Index"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Playlist_SwapDown": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Index"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMatchSettingsManager": {
+      "props": {
+        "Boolean": [
+          "MatchSettings_EditScriptSettings_Ongoing"
+        ],
+        "CMatchSettings[]": [
+          "MatchSettings"
+        ]
+      },
+      "methods": {
+        "MatchSettings_Refresh": {
+          "params": [],
+          "returns": "Void"
+        },
+        "MatchSettings_Create": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FilePath"
+            }
+          ],
+          "returns": "CMatchSettings"
+        },
+        "MatchSettings_Save": {
+          "params": [
+            {
+              "identifier": "CMatchSettings",
+              "argument": "MatchSettings"
+            }
+          ],
+          "returns": "Void"
+        },
+        "MatchSettings_SaveAs": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "FilePath"
+            },
+            {
+              "identifier": "CMatchSettings",
+              "argument": "MatchSettings"
+            }
+          ],
+          "returns": "CMatchSettings"
+        },
+        "MatchSettings_EditScriptSettings": {
+          "params": [
+            {
+              "identifier": "CMatchSettings",
+              "argument": "MatchSettings"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlBrowser": {
+      "props": {
+        "CManiaAppBrowser": [
+          "ParentApp"
+        ],
+        "CMap": [
+          "CurMap"
+        ],
+        "EBuddyResult": [
+          "BuddyDoResult"
+        ],
+        "Text": [
+          "BuddyDoErrorMessage",
+          "BrowserFocusedFrameId"
+        ],
+        "Boolean": [
+          "IsInBrowser"
+        ]
+      },
+      "methods": {
+        "ShowCurMapCard": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserBack": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserQuit": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserHome": {
+          "params": [],
+          "returns": "Void"
+        },
+        "BrowserReload": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetLocalUserClubLink": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ClubLink"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlControl": {
+      "props": {
+        "CMlFrame": [
+          "Parent"
+        ],
+        "Text": [
+          "ControlId",
+          "ToolTip"
+        ],
+        "Text[]": [
+          "ControlClasses"
+        ],
+        "Vec2": [
+          "Size",
+          "RelativePosition_V3",
+          "AbsolutePosition_V3"
+        ],
+        "AlignHorizontal": [
+          "HorizontalAlign"
+        ],
+        "AlignVertical": [
+          "VerticalAlign"
+        ],
+        "Boolean": [
+          "Visible",
+          "IsFocused"
+        ],
+        "Real": [
+          "ZIndex",
+          "RelativeScale",
+          "RelativeRotation",
+          "AbsoluteScale",
+          "AbsoluteRotation"
+        ]
+      },
+      "methods": {
+        "HasClass": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Class"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "DataAttributeExists": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "DataName"
+            }
+          ],
+          "returns": "Boolean"
+        },
+        "DataAttributeGet": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "DataName"
+            }
+          ],
+          "returns": "Text"
+        },
+        "DataAttributeSet": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "DataName"
+            },
+            {
+              "identifier": "Text",
+              "argument": "DataValue"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Show": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Hide": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Unload": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Focus": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlEntry": {
+      "props": {
+        "Text": [
+          "Value"
+        ],
+        "ETextFormat": [
+          "TextFormat"
+        ],
+        "Real": [
+          "Opacity",
+          "TextSizeReal"
+        ],
+        "Vec3": [
+          "TextColor"
+        ],
+        "Integer": [
+          "MaxLine"
+        ],
+        "Boolean": [
+          "AutoNewLine"
+        ]
+      },
+      "methods": {
+        "StartEdition": {
+          "params": [],
+          "returns": "Void"
+        },
+        "SetText": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "NewText"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "SendSubmitEvent"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlFileEntry": {
+      "props": {
+        "Text": [
+          "FullFileName"
+        ]
+      }
+    },
+    "CMlFrame": {
+      "props": {
+        "CMlControl[]": [
+          "Controls"
+        ],
+        "Boolean": [
+          "ClipWindowActive",
+          "DisablePreload"
+        ],
+        "Vec2": [
+          "ClipWindowRelativePosition",
+          "ClipWindowSize"
+        ]
+      },
+      "methods": {
+        "GetFirstChild": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ControlId"
+            }
+          ],
+          "returns": "CMlControl"
+        }
+      }
+    },
+    "CMlGauge": {
+      "props": {
+        "Text": [
+          "Style"
+        ],
+        "Real": [
+          "Ratio",
+          "GradingRatio"
+        ],
+        "Integer": [
+          "Clan"
+        ],
+        "Vec3": [
+          "Color"
+        ],
+        "Boolean": [
+          "DrawBackground",
+          "DrawBlockBackground",
+          "CenteredBar"
+        ]
+      },
+      "methods": {
+        "SetRatio": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "NewRatio"
+            }
+          ],
+          "returns": "Void"
+        },
+        "SetClan": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "NewClan"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlGraph": {
+      "props": {
+        "Vec2": [
+          "CoordsMin",
+          "CoordsMax"
+        ],
+        "CMlGraphCurve[]": [
+          "Curves"
+        ]
+      },
+      "methods": {
+        "AddCurve": {
+          "params": [],
+          "returns": "CMlGraphCurve"
+        },
+        "RemoveCurve": {
+          "params": [
+            {
+              "identifier": "CMlGraphCurve",
+              "argument": "Curve"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlGraphCurve": {
+      "props": {
+        "Vec2[]": [
+          "Points"
+        ],
+        "Vec3": [
+          "Color"
+        ],
+        "Text": [
+          "Style"
+        ],
+        "Real": [
+          "Width"
+        ]
+      },
+      "methods": {
+        "SortPoints": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlLabel": {
+      "props": {
+        "Text": [
+          "Style",
+          "Substyle",
+          "TextFont",
+          "Value"
+        ],
+        "Integer": [
+          "ValueLineCount",
+          "MaxLine"
+        ],
+        "Boolean": [
+          "AppendEllipsis",
+          "AutoNewLine"
+        ],
+        "Real": [
+          "LineSpacing",
+          "Opacity",
+          "TextSizeReal"
+        ],
+        "Vec3": [
+          "TextColor"
+        ],
+        "EBlendMode": [
+          "Blend"
+        ]
+      },
+      "methods": {
+        "SetText": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "NewText"
+            }
+          ],
+          "returns": "Void"
+        },
+        "ComputeWidth": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Text"
+            }
+          ],
+          "returns": "Real"
+        },
+        "ComputeHeight": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Text"
+            }
+          ],
+          "returns": "Real"
+        }
+      }
+    },
+    "CMlMediaPlayer": {
+      "props": {
+        "Boolean": [
+          "IsInitPlay",
+          "Music",
+          "IsLooping"
+        ],
+        "Real": [
+          "Volume"
+        ],
+        "Text": [
+          "Url"
+        ]
+      },
+      "methods": {
+        "Play": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Stop": {
+          "params": [],
+          "returns": "Void"
+        },
+        "StopAndRewind": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlMinimap": {
+      "props": {
+        "Vec3": [
+          "WorldPosition"
+        ],
+        "Vec2": [
+          "MapPosition"
+        ],
+        "Real": [
+          "MapYaw",
+          "ZoomFactor"
+        ],
+        "Boolean": [
+          "Underground"
+        ]
+      },
+      "methods": {
+        "Fog_SetAll": {
+          "params": [
+            {
+              "identifier": "Real",
+              "argument": "Value"
+            }
+          ],
+          "returns": "Void"
+        },
+        "Fog_ClearDisk": {
+          "params": [
+            {
+              "identifier": "Vec3",
+              "argument": "WorldCenter"
+            },
+            {
+              "identifier": "Real",
+              "argument": "Radius"
+            },
+            {
+              "identifier": "Real",
+              "argument": "FadeSize"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlPage": {
+      "props": {
+        "CMlFrame": [
+          "MainFrame"
+        ],
+        "Boolean": [
+          "LinksInhibited"
+        ],
+        "CMlControl[]": [
+          "GetClassChildren_Result"
+        ]
+      },
+      "methods": {
+        "GetFirstChild": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "ControlId"
+            }
+          ],
+          "returns": "CMlControl"
+        },
+        "GetClassChildren": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "Class"
+            },
+            {
+              "identifier": "CMlFrame",
+              "argument": "Frame"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "Recursive"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
+    "CMlQuad": {
+      "props": {
+        "CImage": [
+          "Image"
+        ],
+        "Text": [
+          "ImageUrl",
+          "ImageUrlFocus",
+          "Style",
+          "Substyle"
+        ],
+        "Boolean": [
+          "StyleSelected",
+          "DownloadInProgress"
+        ],
+        "Vec3": [
+          "Colorize",
+          "ModulateColor",
+          "BgColor",
+          "BgColorFocus"
+        ],
+        "Real": [
+          "Opacity"
+        ],
+        "EKeepRatioMode": [
+          "KeepRatio"
+        ],
+        "EBlendMode": [
+          "Blend"
+        ]
+      },
+      "methods": {
+        "ChangeImageUrl": {
+          "params": [
+            {
+              "identifier": "Text",
+              "argument": "fieldName"
+            }
+          ],
+          "returns": "Void"
+        }
+      }
+    },
     "CMlScript": {
       "props": {
         "CMlPage": [
@@ -4249,6 +4987,7 @@
         ],
         "Boolean": [
           "PageIsVisible",
+          "Dbg_WarnOnDroppedEvents",
           "MouseLeftButton",
           "MouseRightButton",
           "MouseMiddleButton",
@@ -4269,7 +5008,8 @@
         ],
         "Text": [
           "CurrentTimeText",
-          "CurrentLocalDateText"
+          "CurrentLocalDateText",
+          "CurrentTimezone"
         ],
         "CUser": [
           "LocalUser"
@@ -4277,7 +5017,13 @@
         "CTitle": [
           "LoadedTitle"
         ],
-        "CMlEvent[]": [
+        "ESystemPlatform": [
+          "SystemPlatform"
+        ],
+        "ESystemSkuIdentifier": [
+          "SystemSkuIdentifier"
+        ],
+        "CMlScriptEvent[]": [
           "PendingEvents"
         ],
         "Real": [
@@ -4290,11 +5036,41 @@
         "CHttpManager": [
           "Http"
         ],
+        "CVideoManager": [
+          "Video"
+        ],
         "CAudioManager": [
           "Audio"
+        ],
+        "CInputManager": [
+          "Input"
+        ],
+        "CDataFileMgr": [
+          "DataFileMgr"
+        ],
+        "CScoreMgr": [
+          "ScoreMgr"
+        ],
+        "CPrivilegeMgr": [
+          "PrivilegeMgr"
+        ],
+        "CPresenceMgr": [
+          "PresenceMgr"
+        ],
+        "CAnimManager": [
+          "AnimManager"
         ]
       },
       "methods": {
+        "Dbg_SetProcessed": {
+          "params": [
+            {
+              "identifier": "CMlScriptEvent",
+              "argument": "Event"
+            }
+          ],
+          "returns": "Void"
+        },
         "IsKeyPressed": {
           "params": [
             {
@@ -4368,245 +5144,52 @@
             }
           ],
           "returns": "Void"
+        },
+        "PreloadAll": {
+          "params": [],
+          "returns": "Void"
+        },
+        "Dbg_DumpDeclareForVariables": {
+          "params": [
+            {
+              "identifier": "CNod",
+              "argument": "Nod"
+            },
+            {
+              "identifier": "Boolean",
+              "argument": "StatsOnly"
+            }
+          ],
+          "returns": "Void"
         }
       }
     },
-    "CMlEntry": {
+    "CMlScriptEvent": {
       "props": {
-        "Text": [
-          "Value"
+        "Type": [
+          "Type"
         ],
         "Integer": [
-          "MaxLine"
-        ],
-        "Boolean": [
-          "AutoNewLine"
-        ]
-      },
-      "methods": {
-        "StartEdition": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlFileEntry": {
-      "props": {
-        "Text": [
-          "FullFileName"
-        ]
-      }
-    },
-    "CMlLabel": {
-      "props": {
-        "Text": [
-          "Style",
-          "Substyle",
-          "TextFont",
-          "Value"
-        ],
-        "Integer": [
-          "ValueLineCount",
-          "MaxLine",
-          "TextSize"
-        ],
-        "Boolean": [
-          "AppendEllipsis",
-          "AutoNewLine"
-        ],
-        "Real": [
-          "Opacity"
-        ],
-        "Vec3": [
-          "TextColor"
-        ]
-      },
-      "methods": {
-        "SetText": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "NewText"
-            }
-          ],
-          "returns": "Void"
-        },
-        "ComputeWidth": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Text"
-            }
-          ],
-          "returns": "Real"
-        }
-      }
-    },
-    "CMlQuad": {
-      "props": {
-        "Text": [
-          "ImageUrl",
-          "ImageUrlFocus",
-          "Style",
-          "Substyle"
-        ],
-        "Boolean": [
-          "StyleSelected",
-          "DownloadInProgress"
-        ],
-        "Vec3": [
-          "Colorize",
-          "ModulateColor",
-          "BgColor",
-          "BgColorFocus"
-        ],
-        "Real": [
-          "Opacity"
-        ],
-        "EKeepRatioMode": [
-          "KeepRatio"
-        ]
-      },
-      "methods": {
-        "ChangeImageUrl": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "fieldName"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlGauge": {
-      "props": {
-        "Text": [
-          "Style"
-        ],
-        "Real": [
-          "Ratio",
-          "GradingRatio"
-        ],
-        "Integer": [
-          "Clan"
-        ],
-        "Vec3": [
-          "Color"
-        ],
-        "Boolean": [
-          "DrawBackground",
-          "DrawBlockBackground",
-          "CenteredBar"
-        ]
-      },
-      "methods": {
-        "SetRatio": {
-          "params": [
-            {
-              "identifier": "Real",
-              "argument": "NewRatio"
-            }
-          ],
-          "returns": "Void"
-        },
-        "SetClan": {
-          "params": [
-            {
-              "identifier": "Integer",
-              "argument": "NewClan"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlGraph": {
-      "props": {
-        "Vec2": [
-          "CoordsMin",
-          "CoordsMax"
-        ],
-        "CMlGraphCurve[]": [
-          "Curves"
-        ]
-      },
-      "methods": {
-        "AddCurve": {
-          "params": [],
-          "returns": "CMlGraphCurve"
-        },
-        "RemoveCurve": {
-          "params": [
-            {
-              "identifier": "CMlGraphCurve",
-              "argument": "Curve"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlMinimap": {
-      "props": {
-        "Vec3": [
-          "WorldPosition"
-        ],
-        "Vec2": [
-          "MapPosition"
-        ],
-        "Real": [
-          "MapYaw",
-          "ZoomFactor"
-        ]
-      }
-    },
-    "CMlBrowser": {
-      "props": {
-        "CMap": [
-          "CurMap"
-        ],
-        "EBuddyResult": [
-          "BuddyDoResult"
+          "KeyCode"
         ],
         "Text": [
-          "BuddyDoErrorMessage",
-          "BrowserFocusedFrameId"
+          "KeyName",
+          "CharPressed",
+          "ControlId",
+          "CustomEventType"
+        ],
+        "CMlControl": [
+          "Control"
+        ],
+        "EMenuNavAction": [
+          "MenuNavAction"
         ],
         "Boolean": [
-          "IsInBrowser"
+          "IsActionAutoRepeat"
+        ],
+        "Text[]": [
+          "CustomEventData"
         ]
-      },
-      "methods": {
-        "ShowCurMapCard": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserBack": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserQuit": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserHome": {
-          "params": [],
-          "returns": "Void"
-        },
-        "BrowserReload": {
-          "params": [],
-          "returns": "Void"
-        },
-        "SetLocalUserClubLink": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ClubLink"
-            }
-          ],
-          "returns": "Void"
-        }
       }
     },
     "CStation": {
@@ -5656,47 +6239,6 @@
       "props": {},
       "methods": {}
     },
-    "CMlPage": {
-      "props": {
-        "CMlFrame": [
-          "MainFrame"
-        ],
-        "Boolean": [
-          "LinksInhibited"
-        ],
-        "CMlControl[]": [
-          "GetClassChildren_Result"
-        ]
-      },
-      "methods": {
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ControlId"
-            }
-          ],
-          "returns": "CMlControl"
-        },
-        "GetClassChildren": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Class"
-            },
-            {
-              "identifier": "CMlFrame",
-              "argument": "Frame"
-            },
-            {
-              "identifier": "Boolean",
-              "argument": "Recursive"
-            }
-          ],
-          "returns": "Void"
-        }
-      }
-    },
     "CUser": {
       "props": {
         "Text": [
@@ -5764,31 +6306,6 @@
         ]
       }
     },
-    "CMlEvent": {
-      "props": {
-        "Type": [
-          "Type"
-        ],
-        "Integer": [
-          "KeyCode"
-        ],
-        "Text": [
-          "KeyName",
-          "CharPressed",
-          "ControlId",
-          "CustomEventType"
-        ],
-        "CMlControl": [
-          "Control"
-        ],
-        "EMenuNavAction": [
-          "MenuNavAction"
-        ],
-        "Text[]": [
-          "CustomEventData"
-        ]
-      }
-    },
     "CXmlManager": {
       "props": {
         "CXmlDocument[]": [
@@ -5824,118 +6341,6 @@
               "argument": "Document"
             }
           ],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlControl": {
-      "props": {
-        "Text": [
-          "ControlId"
-        ],
-        "Text[]": [
-          "ControlClasses"
-        ],
-        "Vec2": [
-          "Size"
-        ],
-        "AlignHorizontal": [
-          "HorizontalAlign"
-        ],
-        "AlignVertical": [
-          "VerticalAlign"
-        ],
-        "Boolean": [
-          "Visible"
-        ],
-        "Vec3": [
-          "RelativePosition",
-          "AbsolutePosition"
-        ],
-        "Real": [
-          "RelativeScale",
-          "RelativeRotation",
-          "AbsoluteScale",
-          "AbsoluteRotation"
-        ]
-      },
-      "methods": {
-        "HasClass": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "Class"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "DataAttributeExists": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            }
-          ],
-          "returns": "Boolean"
-        },
-        "DataAttributeGet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            }
-          ],
-          "returns": "Text"
-        },
-        "DataAttributeSet": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "DataName"
-            },
-            {
-              "identifier": "Text",
-              "argument": "DataValue"
-            }
-          ],
-          "returns": "Void"
-        },
-        "Show": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Hide": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Unload": {
-          "params": [],
-          "returns": "Void"
-        },
-        "Focus": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
-    "CMlGraphCurve": {
-      "props": {
-        "Vec2[]": [
-          "Points"
-        ],
-        "Vec3": [
-          "Color"
-        ],
-        "Text": [
-          "Style"
-        ],
-        "Real": [
-          "Width"
-        ]
-      },
-      "methods": {
-        "SortPoints": {
-          "params": [],
           "returns": "Void"
         }
       }
@@ -6700,50 +7105,6 @@
         ]
       }
     },
-    "CMapType": {
-      "props": {
-        "Boolean": [
-          "CustomEditAnchorData",
-          "ValidationEndRequested",
-          "IsSwitchedToPlayground"
-        ],
-        "ValidationStatus": [
-          "ValidationStatus"
-        ],
-        "Text": [
-          "ValidabilityRequirementsMessage"
-        ],
-        "CUIConfigMgr": [
-          "UIManager"
-        ],
-        "CUser[]": [
-          "Users"
-        ]
-      },
-      "methods": {
-        "ClearMapMetadata": {
-          "params": [],
-          "returns": "Void"
-        },
-        "StartTestMapWithMode": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "RulesModeName"
-            }
-          ],
-          "returns": "Void"
-        },
-        "RequestEnterPlayground": {
-          "params": [],
-          "returns": "Void"
-        },
-        "RequestLeavePlayground": {
-          "params": [],
-          "returns": "Void"
-        }
-      }
-    },
     "CTmMlPlayer": {
       "props": {
         "Integer": [
@@ -6888,31 +7249,6 @@
         ]
       }
     },
-    "CMlFrame": {
-      "props": {
-        "CMlControl[]": [
-          "Controls"
-        ],
-        "Boolean": [
-          "ClipWindowActive"
-        ],
-        "Vec2": [
-          "ClipWindowRelativePosition",
-          "ClipWindowSize"
-        ]
-      },
-      "methods": {
-        "GetFirstChild": {
-          "params": [
-            {
-              "identifier": "Text",
-              "argument": "ControlId"
-            }
-          ],
-          "returns": "CMlControl"
-        }
-      }
-    },
     "CXmlDocument": {
       "props": {
         "Text": [
@@ -6935,30 +7271,6 @@
           ],
           "returns": "CXmlNode"
         }
-      }
-    },
-    "CMapInfo": {
-      "props": {
-        "Ident": [
-          "MapUid"
-        ],
-        "Text": [
-          "Comments",
-          "CollectionName",
-          "AuthorLogin",
-          "AuthorNickName",
-          "AuthorZonePath",
-          "MapType",
-          "MapStyle",
-          "Name",
-          "Path"
-        ],
-        "Integer": [
-          "CopperPrice"
-        ],
-        "Boolean": [
-          "Unlocked"
-        ]
       }
     },
     "CTeam": {

--- a/lib/completions/completions.json
+++ b/lib/completions/completions.json
@@ -75,7 +75,7 @@
               "argument": "Params"
             }
           ],
-          "return" : "Void"
+          "returns" : "Void"
         }
       }
     },
@@ -144,7 +144,7 @@
               "argument": "EasingFunc"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "AddChain": {
           "params": [
@@ -165,7 +165,7 @@
               "argument": "EasingFunc"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         }
       }
     },
@@ -349,7 +349,7 @@
               "argument": "Slot"
             }
           ],
-          "return": "Text"
+          "returns": "Text"
         },
         "StickerSlot_Set": {
           "params": [
@@ -362,11 +362,11 @@
               "argument": "Sticker"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "StickerSlot_Clear": {
           "params": [],
-          "return": "Void"
+          "returns": "Void"
         }
       }
     },
@@ -398,19 +398,19 @@
       "methods": {
         "Leave": {
           "params": [],
-          "return": "Void"
+          "returns": "Void"
         },
         "MeshId_Next": {
           "params": [],
-          "return": "Void"
+          "returns": "Void"
         },
         "MeshId_Previous": {
           "params": [],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeCreate": {
           "params": [],
-          "return": "CBadge"
+          "returns": "CBadge"
         },
         "BadgeDestroy": {
           "params": [
@@ -419,7 +419,7 @@
               "argument": "Badge"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeCopy": {
           "params": [
@@ -432,7 +432,7 @@
               "argument": "Destination"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeReadFromProfile": {
           "params": [
@@ -445,7 +445,7 @@
               "argument": "UserId"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeWriteToProfile": {
           "params": [
@@ -458,7 +458,7 @@
               "argument": "UserId"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         }
       }
     },
@@ -471,7 +471,7 @@
       "methods": {
         "BadgeCreate": {
           "params": [],
-          "return": "CBadge"
+          "returns": "CBadge"
         },
         "BadgeDestroy": {
           "params": [
@@ -480,7 +480,7 @@
               "argument": "Badge"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeCopy": {
           "params": [
@@ -493,7 +493,7 @@
               "argument": "Destination"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeReadFromProfile": {
           "params": [
@@ -506,7 +506,7 @@
               "argument": "UserId"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "BadgeWriteToProfile": {
           "params": [
@@ -519,7 +519,7 @@
               "argument": "UserId"
             }
           ],
-          "return": "Void"
+          "returns": "Void"
         },
         "ProfileIsReady": {
           "param": [
@@ -528,8 +528,178 @@
               "argument": "UserId"
             }
           ],
-          "return": "Boolean"
+          "returns": "Boolean"
         }
+      }
+    },
+    "CBlock": {
+      "props": {
+        "Integer": [
+          "BlockScriptId"
+        ],
+        "Boolean": [
+          "CanHaveAnchor"
+        ],
+        "Int3": [
+          "Coord"
+        ],
+        "CardinalDirections": [
+          "Direction"
+        ],
+        "CBlockUnit[]": [
+          "BlockUnits"
+        ],
+        "CBlockModel": [
+          "BlockModel"
+        ]
+      },
+      "methods": {
+        "UseDefaultAnchor": {
+          "params": [],
+          "returns": "Void"
+        },
+        "UseCustomAnchor": {
+          "params": [],
+          "returns": "Void"
+        }
+      }
+    },
+    "CBlockModel": {
+      "props": {
+        "Text": [
+          "Name"
+        ],
+        "Boolean": [
+          "IsRoad",
+          "IsTerrain",
+          "isPodium",
+          "NoRespawn"
+        ],
+        "EWayPointType": [
+          "WaypointType"
+        ],
+        "CBlockModelVariantGround": [
+          "VariantGround"
+        ],
+        "CBlockModelVariantAir": [
+          "VariantAir"
+        ]
+      }
+    },
+    "CBlockModelClip": {
+    },
+    "CBlockModelVariant": {
+      "props": {
+        "Text": [
+          "Name"
+        ],
+        "Boolean": [
+          "IsAllUnderground",
+          "IsPartUnderground"
+        ],
+        "Int3": [
+          "Size",
+          "OffsetBoundingBoxMin",
+          "OffsetBoundingBoxMax"
+        ],
+        "CBlockUnitModel[]": [
+          "BlockUnitModels"
+        ]
+      }
+    },
+    "CBlockUnit": {
+      "props": {
+        "Int3": [
+          "Offset"
+        ],
+        "CBlockUnitModel": [
+          "BlockUnitModel"
+        ],
+        "CBlock": [
+          "Block"
+        ]
+      }
+    },
+    "CBlockUnitModel": {
+      "props": {
+        "Int3": [
+          "Offset"
+        ],
+        "CBlockModelClip[]": [
+          "Clips"
+        ]
+      }
+    },
+    "CCampaign": {
+      "props": {
+        "Text": [
+          "CampaignId",
+          "ScoreContext"
+        ],
+        "CMapGroup[]": [
+          "MapGroups"
+        ],
+        "Boolean": [
+          "OfficialRecordEnabled"
+        ]
+      },
+      "methods": {
+        "GetMapGroupCount": {
+          "params": [],
+          "returns": "Integer"
+        },
+        "GetMapGroup": {
+          "params": [
+            {
+              "identifier": "Integer",
+              "argument": "Index"
+            }
+          ],
+          "return": "CMapGroup"
+        },
+        "GetNextMap": {
+          "params": [
+            {
+              "identifier": "CMapInfo",
+              "argument": "CurrentMapInfo"
+            }
+          ]
+        }
+      }
+    },
+    "CClient": {
+      "props": {
+        "CUser": [
+          "User"
+        ],
+        "CUIConfig": [
+          "UI"
+        ],
+        "Boolean": [
+          "IsConnectedToMasterServer",
+          "IsSpectator"
+        ],
+        "Text": [
+          "ClientVersion",
+          "ClientTitleVersion"
+        ],
+        "Integer": [
+          "IdleDuration"
+        ]
+      }
+    },
+    "CCollector": {
+      "props": {
+        "Text": [
+          "Name",
+          "PageName"
+        ],
+        "Integer": [
+          "InterfaceNumber"
+        ],
+        "CImage": [
+          "Icon"
+        ]
       }
     },
     "CMlScript": {
@@ -3086,27 +3256,6 @@
         ]
       }
     },
-    "CBlockModel": {
-      "props": {
-        "Text": [
-          "Name"
-        ],
-        "Boolean": [
-          "IsRoad",
-          "IsTerrain",
-          "NoRespawn"
-        ],
-        "EWayPointType": [
-          "WaypointType"
-        ],
-        "CBlockModelVariantGround": [
-          "VariantGround"
-        ],
-        "CBlockModelVariantAir": [
-          "VariantAir"
-        ]
-      }
-    },
     "CMacroblockModel": {
       "props": {
         "Boolean": [
@@ -3128,38 +3277,6 @@
         "Vec3": [
           "Position"
         ]
-      }
-    },
-    "CBlock": {
-      "props": {
-        "Integer": [
-          "BlockScriptId"
-        ],
-        "Boolean": [
-          "CanHaveAnchor"
-        ],
-        "Int3": [
-          "Coord"
-        ],
-        "CardinalDirections": [
-          "Direction"
-        ],
-        "CBlockUnit[]": [
-          "BlockUnits"
-        ],
-        "CBlockModel": [
-          "BlockModel"
-        ]
-      },
-      "methods": {
-        "UseDefaultAnchor": {
-          "params": [],
-          "returns": "Void"
-        },
-        "UseCustomAnchor": {
-          "params": [],
-          "returns": "Void"
-        }
       }
     },
     "CMode": {
@@ -4180,27 +4297,6 @@
         ]
       }
     },
-    "CCollector": {
-      "props": {
-        "Text": [
-          "Name",
-          "PageName"
-        ]
-      }
-    },
-    "CBlockUnit": {
-      "props": {
-        "Int3": [
-          "Offset"
-        ],
-        "CBlockUnitModel": [
-          "BlockUnitModel"
-        ],
-        "CBlock": [
-          "Block"
-        ]
-      }
-    },
     "CTeam": {
       "props": {
         "Text": [
@@ -4758,35 +4854,6 @@
           ],
           "returns": "CXmlNode"
         }
-      }
-    },
-    "CBlockModelVariant": {
-      "props": {
-        "Text": [
-          "Name"
-        ],
-        "Boolean": [
-          "IsAllUnderground",
-          "IsPartUnderground"
-        ],
-        "Int3": [
-          "Size",
-          "OffsetBoundingBoxMin",
-          "OffsetBoundingBoxMax"
-        ],
-        "CBlockUnitModel[]": [
-          "BlockUnitModels"
-        ]
-      }
-    },
-    "CBlockUnitModel": {
-      "props": {
-        "Int3": [
-          "Offset"
-        ],
-        "CBlockModelClip[]": [
-          "Clips"
-        ]
       }
     },
     "CXmlRpcEvent": {

--- a/lib/completions/index.js
+++ b/lib/completions/index.js
@@ -4,11 +4,12 @@ const fuzz = require('fuzzaldrin')
 const {classes, classMethods, classProps} = require('./classes')
 const primitives = require('./primitives')
 const keywords = require('./keywords')
-const modules = require('./modules')
-const index = [...classes, ...primitives, ...keywords, ...modules]
+const {modules} = require('./modules')
+const index = [...classes, ...primitives, ...keywords, ...modules()]
 
 
 function findFromDelimeter(delimeter, searchFor) {   
+  console.log(modules())
   try {
     assert(delimeter === '::' || delimeter === '.', 'Invalid delimeter');
     const searchKeys = searchFor.split(delimeter);

--- a/lib/completions/index.js
+++ b/lib/completions/index.js
@@ -9,7 +9,6 @@ const index = [...classes, ...primitives, ...keywords, ...modules()]
 
 
 function findFromDelimeter(delimeter, searchFor) {   
-  console.log(modules())
   try {
     assert(delimeter === '::' || delimeter === '.', 'Invalid delimeter');
     const searchKeys = searchFor.split(delimeter);

--- a/lib/completions/modules.js
+++ b/lib/completions/modules.js
@@ -1,10 +1,18 @@
 const { CompletionItem: Item, CompletionItemKind: Kind } = require('vscode')
 
-module.exports = [
-  "#Command",
-  "#Include",
-  "#RequireContext",
-  "#Setting",
-  "#Const",
-  "#Extends"
-].map(label => new Item(label, Kind.Module))
+module.exports = {
+  modules: () => {
+    var groupModules = [
+      "#Command",
+      "#Include",
+      "#RequireContext",
+      "#Setting",
+      "#Const",
+      "#Extends"
+    ].map(label => new Item(label, Kind.Module))
+    for(var i = 0; i<groupModules.length; i++){
+      groupModules[i].insertText = groupModules[i].label.substring(1, groupModules[i].label.length)
+    }
+    return groupModules
+  }
+}

--- a/lib/completions/primitives.js
+++ b/lib/completions/primitives.js
@@ -1,5 +1,4 @@
-const primitives = Object.keys(require('./completions').primitives)
+const primitives = require('./completions').primitives
 const { CompletionItem: Item, CompletionItemKind: Kind } = require('vscode')
 
 module.exports = primitives.map(label => new Item(label, Kind.Value))
-

--- a/package.json
+++ b/package.json
@@ -39,6 +39,12 @@
                 "configuration": "./language-configuration.json"
             }
         ],
+        "snippets": [
+            {
+                "language": "maniascript",
+                "path": "./snippets/maniascript.json"
+            }
+        ],
         "grammars": [
             {
                 "language": "maniascript",

--- a/snippets/maniascript.json
+++ b/snippets/maniascript.json
@@ -1,0 +1,32 @@
+{
+  "Foreach Statement": {
+    "prefix": "foreach",
+    "body": [
+      "foreach (${1:var} in ${2:iterable}) {",
+      "\t$0",
+      "}"
+    ],
+    "description": "foreach statement"
+  },
+  "Switch Statement": {
+    "prefix": "switch",
+    "body": [
+      "switch (${1:var}) {",
+      "\tcase ${2:value} : $0;",
+      "\tdefault: {}",
+      "}"
+    ],
+    "description": "switch statement"
+  },
+  "ifelse": {
+    "prefix": "ifelse",
+    "body": [
+      "if (${1:condition}) {",
+      "\t$0",
+      "} else {",
+      "\t",
+      "}"
+    ],
+    "description": "if else statement"
+  }
+}


### PR DESCRIPTION
Here is an update I made for the maniascript extension.
I have change the format of the completions.json file to add function overloading.
Attributes now show there type in the completion window.
A few snippets have been implemented.
Primitives are now suggest as completion.
I used Uanesco documentation pages to fill the completions.json file

Things I want to work on :
- Snippets when choosing a function to be able to easly fill the arguments
- Add Enum attributes to the completion (Ex: CardinalDirections in CMapEditorPlugin)